### PR TITLE
Fix ResourceAllocatorDma VkDevice initialization in Sample

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -149,7 +149,7 @@ bool Sample::begin()
   m_submission.init(m_context.m_queueGCT.queue);
 
   createTextureSampler();
-  
+  m_allocatorDma.init(m_context.m_device, m_context.getPhysicalDevices().front());
   // Configure shader system (note that this also creates shader modules as we add them)
   {
     // Initialize shader system (this keeps track of shaders so that you can reload all of them at once):


### PR DESCRIPTION
Fixed a crash on startup where CreateBufferEx was called with m_device being nullptr.