### PR TITLE
Fix OOB array access with 4+ swapchain images

### DIFF
--- a/oit.cpp
+++ b/oit.cpp
@@ -304,13 +304,17 @@ void Sample::updateAllDescriptorSets()
 {
   std::vector<VkWriteDescriptorSet> updates;
 
+  // We create one descriptor set per swapchain image.
+  const uint32_t totalDescriptorSets = m_swapChain.getImageCount();
+
   // Information about the buffer and image descriptors we'll use.
   // When constructing VkWriteDescriptorSet objects, we'll take references
   // to these.
 
   // UBO_SCENE
-  std::array<VkDescriptorBufferInfo, 3> uboBufferInfo;
-  for(size_t ring = 0; ring < m_swapChain.getImageCount(); ring++)
+  std::vector<VkDescriptorBufferInfo> uboBufferInfo;
+  uboBufferInfo.resize(totalDescriptorSets);
+  for(uint32_t ring = 0; ring < totalDescriptorSets; ring++)
   {
     uboBufferInfo[ring].buffer = m_uniformBuffers[ring].buffer;
     uboBufferInfo[ring].offset = 0;
@@ -347,7 +351,7 @@ void Sample::updateAllDescriptorSets()
   oitABufferInfo.range                  = VK_WHOLE_SIZE;
 
   // Descriptor sets without the color buffer bound to the shader stage
-  for(uint32_t ring = 0; ring < m_swapChain.getImageCount(); ring++)
+  for(uint32_t ring = 0; ring < totalDescriptorSets; ring++)
   {
     updates.push_back(m_descriptorInfo.makeWrite(ring, UBO_SCENE, &uboBufferInfo[ring]));
 


### PR DESCRIPTION
Some Vulkan implementations may provide more than 3 swapchain images (Mesa RADV giving 4 images in mailbox mode — https://gitlab.freedesktop.org/mesa/mesa/-/issues/6249), resulting in a stack corruption.

While with this change I'm able to run the sample on my machine, I still got another error in the descriptor update somewhere in the driver internals after trying to toggle vsync (`assert(base == NULL || base->type == obj_type)` in Vulkan object logic inside the driver), I haven't fully investigated that issue — but that's probably something for another commit in the future, with this change the sample is functional at all at least.

This adds a dynamically allocated container to `updateAllDescriptorSets`, but this is not a function called every frame — the update is performed only when the images are changed, and there's another local `std::vector` in the function.