### PR TITLE
Stability between frames: use ordered interlock, document in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ If the device supports the `VK_EXT_fragment_shader_interlock` extension, then we
 
 To do this, we call `beginInvocationInterlockARB` or `beginInvocationInterlockNV` before entering the critical section (depending on whether the GLSL code supports the `GL_ARB_fragment_shader_interlock` or `GL_NV_fragment_shader_interlock`extension), then call `endInvocationInterlockARB` or `endInvocationInterlockNV` to end the critical section.
 
-This is similar to the example for Spinlock, except with spin locks replaced by invocation interlocks.
+Additionally, the critical section is entered in primitive order, so the selection of the fragment to tail blend in each invocation is guaranteed to be stable between frames.
+
+The shader code is similar to the example for Spinlock, except with spin locks replaced by invocation interlocks.
 
 ### Weighted, Blended Order-Independent Transparency
 

--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ WBOIT, on the other hand, uses a constant amount of space per pixel/sample, but 
 
 Here's a quick overview of the properties of each algorithm. See the algorithm descriptions below for more details:
 
-| Name        | Correctness Bound By           | MSAA Support | Bytes per Pixel or Sample                                    | Sorts Front | Number of Transparent Draws | Additional Extensions Required |
-| ----------- | ------------------------------ | ------------ | ------------------------------------------------------------ | ----------- | --------------------------- | ------------------------------ |
-| Simple      | `OIT_LAYERS`, draw order       | Yes          | `8*OIT_LAYERS+4`, or `16*OIT_LAYERS+4` (with antialiasing masks) | No          | 1                           | No                             |
-| Linked List | `OIT_LAYERS` and A-buffer size | Yes          | `16` (per element) + `4`                                     | Yes         | 1                           | No                             |
-| Loop32      | `OIT_LAYERS`                   | No           | `8*OIT_LAYERS+4`                                             | Yes         | 2                           | No                             |
-| Loop64      | `OIT_LAYERS`                   | No           | `8*OIT_LAYERS+4`                                             | Yes         | 1                           | Yes                            |
-| Spinlock    | `OIT_LAYERS`                   | Yes          | `8*OIT_LAYERS+12`, or `16*OIT_LAYERS+12` (with antialiasing masks) | Yes         | 1                           | No                             |
-| Interlock   | `OIT_LAYERS`                   | Yes          | `16*OIT_LAYERS+8`, or `32*OIT_LAYERS+8` (with antialiasing masks) | Yes         | 1                           | Yes                            |
-| WBOIT       | Approximation                  | Yes          | `20`                                                         | Yes         | 1                           | No                             |
+| Name        | Correctness Bound By           | MSAA Support | Bytes per Pixel or Sample                                          | Stability Between Frames Guaranteed | Sorts Front | Number of Transparent Draws | Additional Extensions Required |
+| ----------- | ------------------------------ | ------------ | ------------------------------------------------------------------ | ----------------------------------- | ----------- | --------------------------- | ------------------------------ |
+| Simple      | `OIT_LAYERS`, draw order       | Yes          | `8*OIT_LAYERS+4`, or `16*OIT_LAYERS+4` (with antialiasing masks)   | No                                  | No          | 1                           | No                             |
+| Linked List | `OIT_LAYERS` and A-buffer size | Yes          | `16` (per element) + `4`                                           | No                                  | Yes         | 1                           | No                             |
+| Loop32      | `OIT_LAYERS`                   | No           | `8*OIT_LAYERS+4`                                                   | Yes                                 | Yes         | 2                           | No                             |
+| Loop64      | `OIT_LAYERS`                   | No           | `8*OIT_LAYERS+4`                                                   | Without Tail Blend                  | Yes         | 1                           | Yes                            |
+| Spinlock    | `OIT_LAYERS`                   | Yes          | `8*OIT_LAYERS+12`, or `16*OIT_LAYERS+12` (with antialiasing masks) | Without Tail Blend                  | Yes         | 1                           | No                             |
+| Interlock   | `OIT_LAYERS`                   | Yes          | `16*OIT_LAYERS+8`, or `32*OIT_LAYERS+8` (with antialiasing masks)  | Yes                                 | Yes         | 1                           | Yes                            |
+| WBOIT       | Approximation                  | Yes          | `20`                                                               | Yes                                 | Yes         | 1                           | No                             |
 
 This sample stores the vertex and index data for all of its spheres in a single mesh. It draws the faces corresponding to the last `100 - percentTransparent`% of spheres using an opaque shader, then draws the first `percentTransparent`% of spheres using the algorithm's `drawTransparent` method.
 
@@ -70,6 +70,8 @@ At the end of the color shader, the A-buffer will contain the following `(color,
 This algorithm uses 32-bit atomic operations to first sort the depths of each pixel's frontmost `OIT_LAYERS` fragments. It then matches colors to depths, and blends the fragments in order.
 
 For instance, given the four fragments in the Simple example with `OIT_LAYERS` = 2 without antialiasing, the depth shader would compute that the frontmost sorted depths are `(0.1, 0.2)`. This step would also tail blend `(c4, 0.4)` and `(c3, 0.3)`. It would then match the colors to the depths to get `(c1, c2)`, and then blend this together.
+
+Because the final decision on whether each fragment should be included in the list is made for all fragments deterministically, based on their depths, before the color pass, with the remaining fragments tail blended in primitive order, the result is guaranteed to be stable between frames, as long as multiple fragments for a single pixel don't share the same depth.
 
 ### Loop64
 

--- a/oitInterlock.frag.glsl
+++ b/oitInterlock.frag.glsl
@@ -20,10 +20,14 @@
 
 // OIT_INTERLOCK supports MSAA.
 // The color pass sorts the frontmost OIT_LAYERS (depth, color) pairs per pixel
-// in the A-buffer, unordered, tail blending colors that make it in. To do this,
-// we insert the first OIT_LAYERS fragments; any further fragments then test to
-// see if they're in the frontmost OIT_LAYERS fragments so far, and if so,
-// replace the furthest fragment.
+// in the A-buffer, tail blending colors that make it in.
+// To do this, we insert the first OIT_LAYERS fragments; any further fragments
+// then test to see if they're in the frontmost OIT_LAYERS fragments so far, and
+// if so, replace the furthest fragment.
+// Insertion attempts are done in primitive order, so the selection of the
+// fragment to tail blend in each invocation is guaranteed to be stable between
+// frames. Also using the ordered interlock mode even without tail blending for
+// stability if multiple fragments share the same depth.
 // The resolve pass then sorts and blends the fragments from front to back.
 
 #version 460
@@ -45,9 +49,9 @@
 
 #if OIT_SAMPLE_SHADING
 // Enables interlock on individual samples.
-layout(sample_interlock_unordered) in;
+layout(sample_interlock_ordered) in;
 #else   // #if OIT_SAMPLE_SHADING
-layout(pixel_interlock_unordered) in;
+layout(pixel_interlock_ordered) in;
 #endif  // #if OIT_SAMPLE_SHADING
 
 #if GL_NV_fragment_shader_interlock


### PR DESCRIPTION
Currently, the interlock sample uses the unordered interlock mode. This makes it behave like a safer (with regard to common spinlock issues like the forward progress guarantee, busy looping) version of the spinlock method that also doesn't require the lock buffer.

However, the spinlock approach has the issue that fragments are chosen for tail blending in an unspecified order, possibly resulting in "no TV signal"-like noise in the final image due to races. This issue was also brought up in [Nvidia's presentation](https://on-demand.gputechconf.com/gtc/2014/presentations/S4385-order-independent-transparency-opengl.pdf) about the OIT algorithms used in this sample.

Ordered fragment shader interlock, however, makes sure the code trying to insert the fragment and choosing the fragment to tail-blend is executed in a defined — primitive — order. This is the main advantage of fragment shader interlock over other methods with a single pass for objects. This pull request makes use of that guarantee.

In addition, I've added some information about the stability of the algorithms that can aid in choosing the one for the task.