### PR TITLE
Allow loop64 tail blending to evict previously added fragments

### DIFF
--- a/oitLoop64.frag.glsl
+++ b/oitLoop64.frag.glsl
@@ -100,6 +100,7 @@ void main()
   }
 #endif
 
+  bool evict = true;
   if(canInsert)
   {
     // Try to insert zcur in the place of the first element of the array that
@@ -112,6 +113,7 @@ void main()
       if(ztest == packUint2x32(uvec2(0xFFFFFFFFu, 0xFFFFFFFFu)))
       {
         // We just inserted zcur into an empty space in the array.
+        evict = false;
         break;
       }
 
@@ -119,15 +121,16 @@ void main()
     }
   }
 
-  if(canInsert)
+  if(!evict)
   {
-    // Inserted, so make this color transparent:
+    // Inserted without having to evict, so make this color transparent:
     outColor = vec4(0);
   }
   else
   {
 #if OIT_TAILBLEND
-    // Unpack the current color and premultiply it
+    // Unpack the color of the fragment that cannot fit into the A-buffer and
+    // premultiply it
     const uvec2 current      = unpackUint2x32(zcur);
     const vec4  currentColor = unPremultSRGBToLinear(unpackUnorm4x8(current.x));
     outColor                 = vec4(currentColor.rgb * currentColor.a, currentColor.a);


### PR DESCRIPTION
Previously, tail blending could happen only if the early test against the furthest fragment had failed.

That had a few logical issues that resulted in subpar quality:

- Only new fragments could be sent to tail blending, but previously added ones were evicted into the void.
- The early test is an unsynchronized conservative check. Even if it has passed, it can silently fail at any moment later.

Now, the furthest fragment, which is sent to one of the shader invocations as the previous value from `atomicMin`, goes to tail blending instead.

This gives a result that is largely identical to what the spinlock and the unordered interlock methods offer.