### PR TITLE
Added Support for Vulkan Dynamic Rendering and Dynamic Rendering Local Read 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Demonstrates seven different techniques for order-independent transparency (OIT) in Vulkan.
 
+### This demo project has been updated to use Dynamic Rendering over the old Vulkan RenderPasses. 
+
 ![Shows a thousand semitransparent spheres on a gray background with a user interface in the top-left corner.](doc/vk_order_independent_transparency.png)
 
 ## About

--- a/main.cpp
+++ b/main.cpp
@@ -224,7 +224,7 @@ void Sample::updateRendererFromState(bool swapchainSizeChanged, bool forceRebuil
 
     if(renderPassesNeedReinit)
     {
-      createRenderPasses();
+      //createRenderPasses();
     }
 
     if(framebuffersAndDescriptorsNeedReinit)
@@ -416,59 +416,61 @@ void Sample::initScene()
   uploader.deinit();
 }
 
-void Sample::destroyFramebuffers()
-{
-  vkDestroyFramebuffer(m_app->getDevice(), m_mainColorDepthFramebuffer, nullptr);
-  m_mainColorDepthFramebuffer = VK_NULL_HANDLE;
-
-  if(m_weightedFramebuffer != VK_NULL_HANDLE)
-  {
-    vkDestroyFramebuffer(m_app->getDevice(), m_weightedFramebuffer, nullptr);
-    m_weightedFramebuffer = VK_NULL_HANDLE;
-  }
-}
+ void Sample::destroyFramebuffers()
+ {
+//   vkDestroyFramebuffer(m_app->getDevice(), m_mainColorDepthFramebuffer, nullptr);
+//   m_mainColorDepthFramebuffer = VK_NULL_HANDLE;
+//
+//   if(m_weightedFramebuffer != VK_NULL_HANDLE)
+//   {
+//     vkDestroyFramebuffer(m_app->getDevice(), m_weightedFramebuffer, nullptr);
+//     m_weightedFramebuffer = VK_NULL_HANDLE;
+//   }
+ }
 
 void Sample::createFramebuffers()
 {
-  destroyFramebuffers();
-  // TODO: Remove and replace with dynamic rendering
-
-  // Color + depth offscreen framebuffer
-  {
-    const std::array<VkImageView, 2> attachments{m_colorImage.getView(), m_depthImage.getView()};
-    const VkFramebufferCreateInfo    fbInfo{.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
-                                            .renderPass      = m_renderPassColorDepthClear,
-                                            .attachmentCount = static_cast<uint32_t>(attachments.size()),
-                                            .pAttachments    = attachments.data(),
-                                            .width           = m_colorImage.getWidth(),
-                                            .height          = m_colorImage.getHeight(),
-                                            .layers          = 1};
-
-    NVVK_CHECK(vkCreateFramebuffer(m_app->getDevice(), &fbInfo, NULL, &m_mainColorDepthFramebuffer));
-    NVVK_DBG_NAME(m_mainColorDepthFramebuffer);
-  }
-
-  // Weighted color + weighted reveal framebuffer (for Weighted, Blended
-  // Order-Independent Transparency). See the render pass description for more info.
-  if(m_state.algorithm == OIT_WEIGHTED)
-  {
-    const std::array<VkImageView, 4> attachments{m_oitWeightedColorImage.getView(),   //
-                                                 m_oitWeightedRevealImage.getView(),  //
-                                                 m_colorImage.getView(),              //
-                                                 m_depthImage.getView()};
-
-    const VkFramebufferCreateInfo fbInfo{.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
-                                         .renderPass      = m_renderPassWeighted,
-                                         .attachmentCount = static_cast<uint32_t>(attachments.size()),
-                                         .pAttachments    = attachments.data(),
-                                         .width           = m_oitWeightedColorImage.getWidth(),
-                                         .height          = m_oitWeightedColorImage.getHeight(),
-                                         .layers          = 1};
-
-    NVVK_CHECK(vkCreateFramebuffer(m_app->getDevice(), &fbInfo, nullptr, &m_weightedFramebuffer));
-    NVVK_DBG_NAME(m_weightedFramebuffer);
-  }
+  // destroyFramebuffers();
+  // // TODO: Remove and replace with dynamic rendering
+  //
+  // // Color + depth offscreen framebuffer
+  // {
+  //   const std::array<VkImageView, 2> attachments{m_colorImage.getView(), m_depthImage.getView()};
+  //   const VkFramebufferCreateInfo    fbInfo{.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+  //                                           .renderPass      = m_renderPassColorDepthClear,
+  //                                           .attachmentCount = static_cast<uint32_t>(attachments.size()),
+  //                                           .pAttachments    = attachments.data(),
+  //                                           .width           = m_colorImage.getWidth(),
+  //                                           .height          = m_colorImage.getHeight(),
+  //                                           .layers          = 1};
+  //
+  //   NVVK_CHECK(vkCreateFramebuffer(m_app->getDevice(), &fbInfo, NULL, &m_mainColorDepthFramebuffer));
+  //   NVVK_DBG_NAME(m_mainColorDepthFramebuffer);
+  // }
+  //
+  // // Weighted color + weighted reveal framebuffer (for Weighted, Blended
+  // // Order-Independent Transparency). See the render pass description for more info.
+  // if(m_state.algorithm == OIT_WEIGHTED)
+  // {
+  //   const std::array<VkImageView, 4> attachments{m_oitWeightedColorImage.getView(),   //
+  //                                                m_oitWeightedRevealImage.getView(),  //
+  //                                                m_colorImage.getView(),              //
+  //                                                m_depthImage.getView()};
+  //
+  //   const VkFramebufferCreateInfo fbInfo{.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+  //                                        .renderPass      = m_renderPassWeighted,
+  //                                        .attachmentCount = static_cast<uint32_t>(attachments.size()),
+  //                                        .pAttachments    = attachments.data(),
+  //                                        .width           = m_oitWeightedColorImage.getWidth(),
+  //                                        .height          = m_oitWeightedColorImage.getHeight(),
+  //                                        .layers          = 1};
+  //
+  //   NVVK_CHECK(vkCreateFramebuffer(m_app->getDevice(), &fbInfo, nullptr, &m_weightedFramebuffer));
+  //   NVVK_DBG_NAME(m_weightedFramebuffer);
+  // }
 }
+
+#pragma optimize("", off)
 
 VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
                                           const VkShaderModule vertShaderModule,
@@ -535,6 +537,35 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
                                                 .attachmentCount = 1,  // This can be modified below
                                                 .pAttachments    = blendAttachments.data()};
 
+  const VkFormat colorFormat = m_colorImage.getFormat();
+  const VkFormat depthFormat = m_depthImage.getFormat();
+
+  // For WEIGHTED_COLOR blend mode we have 2 color attachments, otherwise 1
+  const uint32_t colorAttachmentCount = (blendMode == BlendMode::WEIGHTED_COLOR) ? 2 : 1;
+
+  std::vector<VkFormat> colorFormats =
+  {
+    colorFormat,
+  };
+
+  if (blendMode == BlendMode::WEIGHTED_COLOR)
+  {
+    colorFormats =
+    {
+      m_oitWeightedColorFormat,
+      m_oitWeightedRevealFormat
+    };
+  }
+
+  const VkPipelineRenderingCreateInfo renderingInfo
+  {
+    .sType                   = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO,
+    .colorAttachmentCount    = colorAttachmentCount,
+    .pColorAttachmentFormats = colorFormats.data(),
+    .depthAttachmentFormat   = depthFormat,
+  };
+
+
   constexpr VkColorComponentFlags allBits =
       VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
   switch(blendMode)
@@ -592,6 +623,7 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
   }
 
   const VkGraphicsPipelineCreateInfo info{.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
+                                          .pNext               = &renderingInfo,
                                           .stageCount          = uint32_t(stages.size()),
                                           .pStages             = stages.data(),
                                           .pVertexInputState   = &vertexInput,
@@ -602,7 +634,7 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
                                           .pDepthStencilState  = &depthStencilState,
                                           .pColorBlendState    = &blendInfo,
                                           .layout              = m_pipelineLayout,
-                                          .renderPass          = renderPass,
+                                          .renderPass          = nullptr,
                                           .subpass             = subpass};
 
   VkPipeline pipeline = VK_NULL_HANDLE;
@@ -813,11 +845,19 @@ int main(int argc, char* argv[])
       .fragmentShaderShadingRateInterlock = VK_FALSE  // (we don't need this)
   };
 
+  VkPhysicalDeviceDynamicRenderingLocalReadFeatures dynamicRenderingFeatures{
+    .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES_KHR,
+    .pNext = nullptr,
+    .dynamicRenderingLocalRead = VK_TRUE
+  };
+
   nvvk::ContextInitInfo vkSetup{
       .instanceExtensions = {VK_EXT_DEBUG_UTILS_EXTENSION_NAME},
       .deviceExtensions   = {nvvk::ExtensionInfo{.extensionName = VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME},
                              nvvk::ExtensionInfo{.extensionName = VK_EXT_POST_DEPTH_COVERAGE_EXTENSION_NAME},
                              nvvk::ExtensionInfo{.extensionName = VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME},
+                             nvvk::ExtensionInfo{.extensionName = VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME},
+                             nvvk::ExtensionInfo{.extensionName = VK_KHR_DYNAMIC_RENDERING_LOCAL_READ_EXTENSION_NAME},
                              nvvk::ExtensionInfo{.extensionName = VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME,
                                                  .feature       = &fragmentShaderInterlockFeatures,
                                                  .required      = false}}};

--- a/main.cpp
+++ b/main.cpp
@@ -220,7 +220,6 @@ void Sample::updateRendererFromState(bool swapchainSizeChanged, bool forceRebuil
     if(framebuffersAndDescriptorsNeedReinit)
     {
       updateAllDescriptorSets();
-      createFramebuffers();
     }
 
     if(shadersNeedUpdate)
@@ -248,8 +247,6 @@ void Sample::onDetach()
   // From updateRendererFromState
   destroyGraphicsPipelines();
   destroyShaderModules();
-  destroyFramebuffers();
-  destroyRenderPasses();
   destroyDescriptorSets();
   destroyFrameImages();
   destroyScene();
@@ -404,60 +401,6 @@ void Sample::initScene()
     m_app->submitAndWaitTempCmdBuffer(cmd);
   }
   uploader.deinit();
-}
-
- void Sample::destroyFramebuffers()
- {
-//   vkDestroyFramebuffer(m_app->getDevice(), m_mainColorDepthFramebuffer, nullptr);
-//   m_mainColorDepthFramebuffer = VK_NULL_HANDLE;
-//
-//   if(m_weightedFramebuffer != VK_NULL_HANDLE)
-//   {
-//     vkDestroyFramebuffer(m_app->getDevice(), m_weightedFramebuffer, nullptr);
-//     m_weightedFramebuffer = VK_NULL_HANDLE;
-//   }
- }
-
-void Sample::createFramebuffers()
-{
-  // destroyFramebuffers();
-  // // TODO: Remove and replace with dynamic rendering
-  //
-  // // Color + depth offscreen framebuffer
-  // {
-  //   const std::array<VkImageView, 2> attachments{m_colorImage.getView(), m_depthImage.getView()};
-  //   const VkFramebufferCreateInfo    fbInfo{.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
-  //                                           .renderPass      = m_renderPassColorDepthClear,
-  //                                           .attachmentCount = static_cast<uint32_t>(attachments.size()),
-  //                                           .pAttachments    = attachments.data(),
-  //                                           .width           = m_colorImage.getWidth(),
-  //                                           .height          = m_colorImage.getHeight(),
-  //                                           .layers          = 1};
-  //
-  //   NVVK_CHECK(vkCreateFramebuffer(m_app->getDevice(), &fbInfo, NULL, &m_mainColorDepthFramebuffer));
-  //   NVVK_DBG_NAME(m_mainColorDepthFramebuffer);
-  // }
-  //
-  // // Weighted color + weighted reveal framebuffer (for Weighted, Blended
-  // // Order-Independent Transparency). See the render pass description for more info.
-  // if(m_state.algorithm == OIT_WEIGHTED)
-  // {
-  //   const std::array<VkImageView, 4> attachments{m_oitWeightedColorImage.getView(),   //
-  //                                                m_oitWeightedRevealImage.getView(),  //
-  //                                                m_colorImage.getView(),              //
-  //                                                m_depthImage.getView()};
-  //
-  //   const VkFramebufferCreateInfo fbInfo{.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
-  //                                        .renderPass      = m_renderPassWeighted,
-  //                                        .attachmentCount = static_cast<uint32_t>(attachments.size()),
-  //                                        .pAttachments    = attachments.data(),
-  //                                        .width           = m_oitWeightedColorImage.getWidth(),
-  //                                        .height          = m_oitWeightedColorImage.getHeight(),
-  //                                        .layers          = 1};
-  //
-  //   NVVK_CHECK(vkCreateFramebuffer(m_app->getDevice(), &fbInfo, nullptr, &m_weightedFramebuffer));
-  //   NVVK_DBG_NAME(m_weightedFramebuffer);
-  // }
 }
 
 VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
@@ -651,8 +594,7 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
                                           .pDepthStencilState  = &depthStencilState,
                                           .pColorBlendState    = &blendInfo,
                                           .layout              = m_pipelineLayout,
-                                          .renderPass          = nullptr,
-                                          .subpass             = subpass};
+                                          .renderPass          = VK_NULL_HANDLE};
 
   VkPipeline pipeline = VK_NULL_HANDLE;
   NVVK_CHECK(vkCreateGraphicsPipelines(m_app->getDevice(), VK_NULL_HANDLE, 1, &info, nullptr, &pipeline));

--- a/main.cpp
+++ b/main.cpp
@@ -540,19 +540,18 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
   const VkFormat colorFormat = m_colorImage.getFormat();
   const VkFormat depthFormat = m_depthImage.getFormat();
 
-  // For WEIGHTED_COLOR blend mode we have 2 color attachments, otherwise 1
   //const uint32_t colorAttachmentCount = (blendMode == BlendMode::WEIGHTED_COLOR) ? 2 : 1;
   uint32_t colorAttachmentCount = 1;
 
   std::vector<VkFormat> colorFormats ={ colorFormat, };
+  std::vector<VkDynamicState> dynamicStates;
 
   if (blendMode == BlendMode::WEIGHTED_COLOR || blendMode == BlendMode::WEIGHTED_COMPOSITE)
   {
-    colorFormats =
-    {
+    colorFormats = {
       m_oitWeightedColorFormat,
       m_oitWeightedRevealFormat,
-      colorFormat
+      colorFormat,
     };
   }
 
@@ -564,6 +563,13 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
     .depthAttachmentFormat   = depthFormat,
   };
 
+  // Setup Dynamic State Info
+  VkPipelineDynamicStateCreateInfo dynamicStateInfo{.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO};
+  if (!dynamicStates.empty())
+  {
+    dynamicStateInfo.dynamicStateCount = static_cast<uint32_t>(dynamicStates.size());
+    dynamicStateInfo.pDynamicStates    = dynamicStates.data();
+  }
 
   constexpr VkColorComponentFlags allBits =
       VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
@@ -587,42 +593,45 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
                                                                                .colorWriteMask = allBits});
       break;
     case BlendMode::WEIGHTED_COLOR:
-      // Test but don't write to depth
-      depthStencilState.depthWriteEnable = false;
-      blendInfo.attachmentCount          = 2;
-      // Pass 1: Write to 0 and 1, leave 2 alone.
-      depthStencilState.depthWriteEnable = false;
-      blendInfo.attachmentCount          = 3;
-      blendAttachments.push_back(               VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
-                                                                               .srcColorBlendFactor = VK_BLEND_FACTOR_ONE,
-                                                                               .dstColorBlendFactor = VK_BLEND_FACTOR_ONE,
-                                                                               .colorBlendOp        = VK_BLEND_OP_ADD,
-                                                                               .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
-                                                                               .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
-                                                                               .colorWriteMask      = allBits});
-      blendAttachments.push_back(               VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
-                                                                               .srcColorBlendFactor = VK_BLEND_FACTOR_ZERO,
-                                                                               .dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR,
-                                                                               .colorBlendOp        = VK_BLEND_OP_ADD,
-                                                                               .srcAlphaBlendFactor = VK_BLEND_FACTOR_ZERO,
-                                                                               .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
-                                                                               .colorWriteMask      = allBits});
-      blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_FALSE, .colorWriteMask = 0});
-    break;
+        // Test but don't write to depth
+        // Pass 1: Write to 0 and 1
+        depthStencilState.depthWriteEnable = false;
+        blendInfo.attachmentCount          = 3;
+        // Attachment 0: Weighted Color
+        blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
+                                                                       .srcColorBlendFactor = VK_BLEND_FACTOR_ONE,
+                                                                       .dstColorBlendFactor = VK_BLEND_FACTOR_ONE,
+                                                                       .colorBlendOp        = VK_BLEND_OP_ADD,
+                                                                       .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
+                                                                       .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
+                                                                       .colorWriteMask      = allBits});
+        // Attachment 1: Reveal
+        blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
+                                                                       .srcColorBlendFactor = VK_BLEND_FACTOR_ZERO,
+                                                                       .dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR,
+                                                                       .colorBlendOp        = VK_BLEND_OP_ADD,
+                                                                       .srcAlphaBlendFactor = VK_BLEND_FACTOR_ZERO,
+                                                                       .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+                                                                       .colorWriteMask      = allBits});
+        // Attachment 2: Main Color (unused in this pass)
+        blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_FALSE, .colorWriteMask = 0});
       break;
     case BlendMode::WEIGHTED_COMPOSITE:
       // Test but don't write to depth
       depthStencilState.depthWriteEnable = false;
-      blendInfo.attachmentCount          = 3;
-      blendAttachments.push_back(                 VkPipelineColorBlendAttachmentState{.blendEnable = VK_FALSE, .colorWriteMask = 0});
-      blendAttachments.push_back(                               VkPipelineColorBlendAttachmentState{.blendEnable = VK_FALSE, .colorWriteMask = 0} );
-      blendAttachments.push_back(              VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
-                                                                               .srcColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
-                                                                               .dstColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA,
-                                                                               .colorBlendOp        = VK_BLEND_OP_ADD,
-                                                                               .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
-                                                                               .dstAlphaBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA,
-                                                                               .colorWriteMask      = allBits});
+      blendInfo.attachmentCount          = 3; // Must match colorFormats
+      // Attachment 0: Weighted Color (unused in this pass)
+      blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_TRUE, .colorWriteMask = 0});
+      // Attachment 1: Reveal (unused in this pass)
+      blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_TRUE, .colorWriteMask = 0});
+      // Attachment 2: Main Color
+      blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
+                                                                     .srcColorBlendFactor = VK_BLEND_FACTOR_ONE,
+                                                                     .dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+                                                                     .colorBlendOp        = VK_BLEND_OP_ADD,
+                                                                     .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
+                                                                     .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+                                                                     .colorWriteMask      = allBits});
       break;
     default:
       assert(!"Blend mode configuration not implemented!");
@@ -635,6 +644,7 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
                                           .pNext               = &renderingInfo,
                                           .stageCount          = uint32_t(stages.size()),
                                           .pStages             = stages.data(),
+                                          //.pDynamicState       = dynamicStates.empty() ? nullptr : &dynamicStateInfo,
                                           .pVertexInputState   = &vertexInput,
                                           .pInputAssemblyState = &inputAssembly,
                                           .pViewportState      = &viewportInfo,

--- a/main.cpp
+++ b/main.cpp
@@ -532,7 +532,7 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
   VkPipelineDepthStencilStateCreateInfo depthStencilState{.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO,
                                                           .depthTestEnable = true,
                                                           .depthCompareOp  = VK_COMPARE_OP_LESS};
-  std::array<VkPipelineColorBlendAttachmentState, 2> blendAttachments{};
+  std::vector<VkPipelineColorBlendAttachmentState> blendAttachments{};
   VkPipelineColorBlendStateCreateInfo blendInfo{.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
                                                 .attachmentCount = 1,  // This can be modified below
                                                 .pAttachments    = blendAttachments.data()};
@@ -541,26 +541,25 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
   const VkFormat depthFormat = m_depthImage.getFormat();
 
   // For WEIGHTED_COLOR blend mode we have 2 color attachments, otherwise 1
-  const uint32_t colorAttachmentCount = (blendMode == BlendMode::WEIGHTED_COLOR) ? 2 : 1;
+  //const uint32_t colorAttachmentCount = (blendMode == BlendMode::WEIGHTED_COLOR) ? 2 : 1;
+  uint32_t colorAttachmentCount = 1;
 
-  std::vector<VkFormat> colorFormats =
-  {
-    colorFormat,
-  };
+  std::vector<VkFormat> colorFormats ={ colorFormat, };
 
-  if (blendMode == BlendMode::WEIGHTED_COLOR)
+  if (blendMode == BlendMode::WEIGHTED_COLOR || blendMode == BlendMode::WEIGHTED_COMPOSITE)
   {
     colorFormats =
     {
       m_oitWeightedColorFormat,
-      m_oitWeightedRevealFormat
+      m_oitWeightedRevealFormat,
+      colorFormat
     };
   }
 
   const VkPipelineRenderingCreateInfo renderingInfo
   {
     .sType                   = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO,
-    .colorAttachmentCount    = colorAttachmentCount,
+    .colorAttachmentCount    = (uint32_t) colorFormats.size(),
     .pColorAttachmentFormats = colorFormats.data(),
     .depthAttachmentFormat   = depthFormat,
   };
@@ -573,54 +572,64 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
     case BlendMode::NONE:
       // Test and write to depth
       depthStencilState.depthWriteEnable = true;
-      blendAttachments[0] = VkPipelineColorBlendAttachmentState{.blendEnable = VK_FALSE, .colorWriteMask = allBits};
+      blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_FALSE, .colorWriteMask = allBits});
       // Leave blending disabled
       break;
     case BlendMode::PREMULTIPLIED:
       // Test but don't write to depth
       depthStencilState.depthWriteEnable = false;
-      blendAttachments[0]                = VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
+      blendAttachments.push_back(                 VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
                                                                                .srcColorBlendFactor = VK_BLEND_FACTOR_ONE,
                                                                                .dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
                                                                                .colorBlendOp        = VK_BLEND_OP_ADD,
                                                                                .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
                                                                                .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
-                                                                               .colorWriteMask = allBits};
+                                                                               .colorWriteMask = allBits});
       break;
     case BlendMode::WEIGHTED_COLOR:
       // Test but don't write to depth
       depthStencilState.depthWriteEnable = false;
       blendInfo.attachmentCount          = 2;
-      blendAttachments[0]                = VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
+      // Pass 1: Write to 0 and 1, leave 2 alone.
+      depthStencilState.depthWriteEnable = false;
+      blendInfo.attachmentCount          = 3;
+      blendAttachments.push_back(               VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
                                                                                .srcColorBlendFactor = VK_BLEND_FACTOR_ONE,
                                                                                .dstColorBlendFactor = VK_BLEND_FACTOR_ONE,
                                                                                .colorBlendOp        = VK_BLEND_OP_ADD,
                                                                                .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
                                                                                .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
-                                                                               .colorWriteMask      = allBits};
-      blendAttachments[1]                = VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
+                                                                               .colorWriteMask      = allBits});
+      blendAttachments.push_back(               VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
                                                                                .srcColorBlendFactor = VK_BLEND_FACTOR_ZERO,
                                                                                .dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR,
                                                                                .colorBlendOp        = VK_BLEND_OP_ADD,
                                                                                .srcAlphaBlendFactor = VK_BLEND_FACTOR_ZERO,
                                                                                .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
-                                                                               .colorWriteMask = allBits};
+                                                                               .colorWriteMask      = allBits});
+      blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_FALSE, .colorWriteMask = 0});
+    break;
       break;
     case BlendMode::WEIGHTED_COMPOSITE:
       // Test but don't write to depth
       depthStencilState.depthWriteEnable = false;
-      blendAttachments[0]                = VkPipelineColorBlendAttachmentState{.blendEnable = VK_TRUE,
+      blendInfo.attachmentCount          = 3;
+      blendAttachments.push_back(                 VkPipelineColorBlendAttachmentState{.blendEnable = VK_FALSE, .colorWriteMask = 0});
+      blendAttachments.push_back(                               VkPipelineColorBlendAttachmentState{.blendEnable = VK_FALSE, .colorWriteMask = 0} );
+      blendAttachments.push_back(              VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
                                                                                .srcColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
                                                                                .dstColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA,
                                                                                .colorBlendOp        = VK_BLEND_OP_ADD,
                                                                                .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
                                                                                .dstAlphaBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA,
-                                                                               .colorWriteMask      = allBits};
+                                                                               .colorWriteMask      = allBits});
       break;
     default:
       assert(!"Blend mode configuration not implemented!");
       break;
   }
+
+  blendInfo.pAttachments = blendAttachments.data();
 
   const VkGraphicsPipelineCreateInfo info{.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
                                           .pNext               = &renderingInfo,

--- a/main.cpp
+++ b/main.cpp
@@ -632,17 +632,17 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
 
       // Attachment 0: Main Color
       blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
-                                                                     .srcColorBlendFactor = VK_BLEND_FACTOR_ONE,
-                                                                     .dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+                                                                     .srcColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+                                                                     .dstColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA,
                                                                      .colorBlendOp        = VK_BLEND_OP_ADD,
-                                                                     .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
-                                                                     .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+                                                                     .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+                                                                     .dstAlphaBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA,
                                                                      .colorWriteMask      = allBits});
 
       // Attachment 1: Weighted Color (unused in this pass)
-      blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_TRUE, .colorWriteMask = 0});
+      blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_FALSE, .colorWriteMask = 0});
       // Attachment 2: Reveal (unused in this pass)
-      blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_TRUE, .colorWriteMask = 0});
+      blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_FALSE, .colorWriteMask = 0});
       break;
     default:
       assert(!"Blend mode configuration not implemented!");

--- a/main.cpp
+++ b/main.cpp
@@ -167,14 +167,11 @@ void Sample::updateRendererFromState(bool swapchainSizeChanged, bool forceRebuil
   const bool framebuffersAndDescriptorsNeedReinit = imagesNeedReinit  //
                                                     || forceRebuildAll;
 
-  const bool renderPassesNeedReinit = (m_state.msaa != m_lastState.msaa)  //
-                                      || forceRebuildAll;
-
   const bool pipelinesNeedReinit = (m_state.algorithm != m_lastState.algorithm)  //
                                    || shadersNeedUpdate || imagesNeedReinit;
 
   const bool anythingChanged = uniformBuffersNeedReinit || shadersNeedUpdate || sceneNeedsReinit || imagesNeedReinit
-                               || descriptorSetsNeedReinit || framebuffersAndDescriptorsNeedReinit || renderPassesNeedReinit;
+                               || descriptorSetsNeedReinit || framebuffersAndDescriptorsNeedReinit;
 
   if(anythingChanged)
   {
@@ -189,8 +186,6 @@ void Sample::updateRendererFromState(bool swapchainSizeChanged, bool forceRebuil
       LOGI("  Frame images\n");
     if(descriptorSetsNeedReinit)
       LOGI("  Descriptor sets\n");
-    if(renderPassesNeedReinit)
-      LOGI("  Render passes\n");
     if(framebuffersAndDescriptorsNeedReinit)
       LOGI("  Framebuffers\n");
     if(shadersNeedUpdate)
@@ -220,11 +215,6 @@ void Sample::updateRendererFromState(bool swapchainSizeChanged, bool forceRebuil
     if(descriptorSetsNeedReinit)
     {
       createDescriptorSets();
-    }
-
-    if(renderPassesNeedReinit)
-    {
-      //createRenderPasses();
     }
 
     if(framebuffersAndDescriptorsNeedReinit)
@@ -475,9 +465,7 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
                                           const VkShaderModule fragShaderModule,
                                           BlendMode            blendMode,
                                           bool                 usesVertexInput,
-                                          bool                 isDoubleSided,
-                                          VkRenderPass         renderPass,
-                                          uint32_t             subpass)
+                                          bool                 isDoubleSided)
 {
   const std::array<VkPipelineShaderStageCreateInfo, 2> stages = {
       VkPipelineShaderStageCreateInfo{.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
@@ -538,12 +526,10 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
   const VkFormat colorFormat = m_colorImage.getFormat();
   const VkFormat depthFormat = m_depthImage.getFormat();
 
-  //const uint32_t colorAttachmentCount = (blendMode == BlendMode::WEIGHTED_COLOR) ? 2 : 1;
-  uint32_t colorAttachmentCount = 1;
-
   std::vector<VkFormat> colorFormats ={ colorFormat, };
   std::vector<VkDynamicState> dynamicStates = {};
 
+  //We are using 3 images in Weigh Blended OIT
   if (blendMode == BlendMode::WEIGHTED_COLOR || blendMode == BlendMode::WEIGHTED_COMPOSITE)
   {
     colorFormats =
@@ -597,7 +583,7 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
         depthStencilState.depthWriteEnable = false;
         blendInfo.attachmentCount          = 3;
 
-        //m_wboitCompositeAttachmentInputIndicesInfo.pNext = &m_wboitColorAttachmentLocationInfo;
+        //Need to pass attachment information to the pipeline
         renderingInfo.pNext = &m_wboitColorAttachmentLocationInfo;
 
         //Attachment 01: Main Color (unused in this pass)
@@ -624,8 +610,12 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
     case BlendMode::WEIGHTED_COMPOSITE:
       // Test but don't write to depth
       depthStencilState.depthWriteEnable = false;
+
+      //Need to pass both read and write shader indices for this pass.
+      //Hence we chain the arrays as below
       m_wboitCompositeAttachmentInputIndicesInfo.pNext = &m_wboitCompositeResetAttachmentLocationsInfo;
       renderingInfo.pNext = &m_wboitCompositeAttachmentInputIndicesInfo;
+
       blendInfo.attachmentCount          = 3;
 
       // Attachment 0: Main Color

--- a/main.cpp
+++ b/main.cpp
@@ -470,8 +470,6 @@ void Sample::createFramebuffers()
   // }
 }
 
-#pragma optimize("", off)
-
 VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
                                           const VkShaderModule vertShaderModule,
                                           const VkShaderModule fragShaderModule,
@@ -599,8 +597,8 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
         depthStencilState.depthWriteEnable = false;
         blendInfo.attachmentCount          = 3;
 
-        //rendering_attachment_index_info.pNext = &locationInfo;
-        renderingInfo.pNext = &locationInfo;
+        //m_wboitCompositeAttachmentInputIndicesInfo.pNext = &m_wboitColorAttachmentLocationInfo;
+        renderingInfo.pNext = &m_wboitColorAttachmentLocationInfo;
 
         //Attachment 01: Main Color (unused in this pass)
         blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_FALSE, .colorWriteMask = 0});
@@ -626,8 +624,8 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
     case BlendMode::WEIGHTED_COMPOSITE:
       // Test but don't write to depth
       depthStencilState.depthWriteEnable = false;
-      rendering_attachment_index_info.pNext = &resetLocationInfo;
-      renderingInfo.pNext = &rendering_attachment_index_info;
+      m_wboitCompositeAttachmentInputIndicesInfo.pNext = &m_wboitCompositeResetAttachmentLocationsInfo;
+      renderingInfo.pNext = &m_wboitCompositeAttachmentInputIndicesInfo;
       blendInfo.attachmentCount          = 3;
 
       // Attachment 0: Main Color

--- a/main.cpp
+++ b/main.cpp
@@ -544,18 +544,19 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
   uint32_t colorAttachmentCount = 1;
 
   std::vector<VkFormat> colorFormats ={ colorFormat, };
-  std::vector<VkDynamicState> dynamicStates;
+  std::vector<VkDynamicState> dynamicStates = {};
 
   if (blendMode == BlendMode::WEIGHTED_COLOR || blendMode == BlendMode::WEIGHTED_COMPOSITE)
   {
-    colorFormats = {
+    colorFormats =
+    {
+      colorFormat,
       m_oitWeightedColorFormat,
       m_oitWeightedRevealFormat,
-      colorFormat,
     };
   }
 
-  const VkPipelineRenderingCreateInfo renderingInfo
+  VkPipelineRenderingCreateInfo renderingInfo
   {
     .sType                   = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO,
     .colorAttachmentCount    = (uint32_t) colorFormats.size(),
@@ -597,7 +598,13 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
         // Pass 1: Write to 0 and 1
         depthStencilState.depthWriteEnable = false;
         blendInfo.attachmentCount          = 3;
-        // Attachment 0: Weighted Color
+
+        //rendering_attachment_index_info.pNext = &locationInfo;
+        renderingInfo.pNext = &locationInfo;
+
+        //Attachment 01: Main Color (unused in this pass)
+        blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_FALSE, .colorWriteMask = 0});
+        // Attachment 1: Weighted Color
         blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
                                                                        .srcColorBlendFactor = VK_BLEND_FACTOR_ONE,
                                                                        .dstColorBlendFactor = VK_BLEND_FACTOR_ONE,
@@ -605,7 +612,7 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
                                                                        .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
                                                                        .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
                                                                        .colorWriteMask      = allBits});
-        // Attachment 1: Reveal
+        // Attachment 2: Reveal
         blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
                                                                        .srcColorBlendFactor = VK_BLEND_FACTOR_ZERO,
                                                                        .dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR,
@@ -613,18 +620,17 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
                                                                        .srcAlphaBlendFactor = VK_BLEND_FACTOR_ZERO,
                                                                        .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
                                                                        .colorWriteMask      = allBits});
-        // Attachment 2: Main Color (unused in this pass)
-        blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_FALSE, .colorWriteMask = 0});
+
+
       break;
     case BlendMode::WEIGHTED_COMPOSITE:
       // Test but don't write to depth
       depthStencilState.depthWriteEnable = false;
-      blendInfo.attachmentCount          = 3; // Must match colorFormats
-      // Attachment 0: Weighted Color (unused in this pass)
-      blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_TRUE, .colorWriteMask = 0});
-      // Attachment 1: Reveal (unused in this pass)
-      blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_TRUE, .colorWriteMask = 0});
-      // Attachment 2: Main Color
+      rendering_attachment_index_info.pNext = &resetLocationInfo;
+      renderingInfo.pNext = &rendering_attachment_index_info;
+      blendInfo.attachmentCount          = 3;
+
+      // Attachment 0: Main Color
       blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable         = VK_TRUE,
                                                                      .srcColorBlendFactor = VK_BLEND_FACTOR_ONE,
                                                                      .dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
@@ -632,6 +638,11 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
                                                                      .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
                                                                      .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
                                                                      .colorWriteMask      = allBits});
+
+      // Attachment 1: Weighted Color (unused in this pass)
+      blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_TRUE, .colorWriteMask = 0});
+      // Attachment 2: Reveal (unused in this pass)
+      blendAttachments.push_back(VkPipelineColorBlendAttachmentState{.blendEnable = VK_TRUE, .colorWriteMask = 0});
       break;
     default:
       assert(!"Blend mode configuration not implemented!");
@@ -644,7 +655,6 @@ VkPipeline Sample::createGraphicsPipeline(const std::string&   debugName,
                                           .pNext               = &renderingInfo,
                                           .stageCount          = uint32_t(stages.size()),
                                           .pStages             = stages.data(),
-                                          //.pDynamicState       = dynamicStates.empty() ? nullptr : &dynamicStateInfo,
                                           .pVertexInputState   = &vertexInput,
                                           .pInputAssemblyState = &inputAssembly,
                                           .pViewportState      = &viewportInfo,

--- a/oit.cpp
+++ b/oit.cpp
@@ -400,188 +400,6 @@ void Sample::destroyRenderPasses()
   }
 }
 
-void Sample::createRenderPasses()
-{
-  destroyRenderPasses();
-
-  // m_renderPassColorDepthClear
-  // Render pass for rendering to m_colorImage and m_depthImage, clearing them
-  // beforehand. Both are in VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL.
-  // We create this manually since (as of this writing) nvvk::createRenderPass
-  // doesn't support multisampling.
-  // {
-  //   std::array<VkAttachmentDescription, 2> attachments = {};  // Color attachment, depth attachment
-  //   // Color attachment
-  //   attachments[0] = VkAttachmentDescription{
-  //       .format         = m_colorImage.getFormat(),
-  //       .samples        = static_cast<VkSampleCountFlagBits>(m_state.msaa),
-  //       .loadOp         = VK_ATTACHMENT_LOAD_OP_CLEAR,
-  //       .storeOp        = VK_ATTACHMENT_STORE_OP_STORE,
-  //       .stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-  //       .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
-  //       .initialLayout  = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-  //       .finalLayout    = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-  //   };
-  //
-  //   // Color attachment reference
-  //   const VkAttachmentReference colorAttachmentRef{.attachment = 0, .layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
-  //
-  //   // Depth attachment
-  //   attachments[1]               = attachments[0];
-  //   attachments[1].format        = m_depthImage.getFormat();
-  //   attachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-  //   attachments[1].finalLayout   = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-  //
-  //   // Depth attachment reference
-  //   const VkAttachmentReference depthAttachmentRef{.attachment = 1, .layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
-  //
-  //   // 1 subpass
-  //   const VkSubpassDescription subpass{.pipelineBindPoint       = VK_PIPELINE_BIND_POINT_GRAPHICS,
-  //                                      .colorAttachmentCount    = 1,
-  //                                      .pColorAttachments       = &colorAttachmentRef,
-  //                                      .pDepthStencilAttachment = &depthAttachmentRef};
-  //
-  //   // We only need to specify one dependency: Since the subpass has a barrier, the subpass will
-  //   // need a self-dependency. (There are implicit external dependencies that are automatically added.)
-  //   const VkSubpassDependency selfDependency{
-  //       .srcSubpass      = 0,
-  //       .dstSubpass      = 0,
-  //       .srcStageMask    = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-  //       .dstStageMask    = selfDependency.srcStageMask,
-  //       .srcAccessMask   = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT,
-  //       .dstAccessMask   = selfDependency.srcAccessMask,
-  //       .dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT  // Required, since we use framebuffer-space stages
-  //   };
-  //
-  //   // No dependency on external data
-  //   const VkRenderPassCreateInfo rpInfo{
-  //       .sType           = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
-  //       .attachmentCount = static_cast<uint32_t>(attachments.size()),
-  //       .pAttachments    = attachments.data(),
-  //       .subpassCount    = 1,
-  //       .pSubpasses      = &subpass,
-  //       .dependencyCount = 1,
-  //       .pDependencies   = &selfDependency,
-  //   };
-  //
-  //   NVVK_CHECK(vkCreateRenderPass(m_app->getDevice(), &rpInfo, NULL, &m_renderPassColorDepthClear));
-  //   NVVK_DBG_NAME(m_renderPassColorDepthClear);
-  //}
-
-  // m_renderPassWeighted
-  // This render pass is used for Weighted, Blended Order-Independent
-  // Transparency. It's somewhat tricky, and has two subpasses, with three
-  // total attachments (weighted color, weighted reveal, color).
-  // The first two attachments are cleared, and the three attachments
-  // are all initially laid out for color attachments.
-  // Subpass 0 takes attachments 0 and 1, and draws to them.
-  // Then subpass 1 takes attachments 0 and 1 as inputs in the
-  // VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL layout and attachment 2 as an
-  // output attachment, and performs the WBOIT resolve step.
-  // See https://www.saschawillems.de/blog/2018/07/19/vulkan-input-attachments-and-sub-passes/
-  // for an example of a different type.
-  //{
-    // Describe the attachments at the beginning and end of the render pass.
-  //   const VkAttachmentDescription weightedColorAttachment{.format  = m_oitWeightedColorFormat,
-  //                                                         .samples = static_cast<VkSampleCountFlagBits>(m_state.msaa),
-  //                                                         .loadOp  = VK_ATTACHMENT_LOAD_OP_CLEAR,
-  //                                                         .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
-  //                                                         .stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-  //                                                         .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
-  //                                                         .initialLayout  = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-  //                                                         .finalLayout    = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
-  //
-  //   VkAttachmentDescription weightedRevealAttachment = weightedColorAttachment;
-  //   weightedRevealAttachment.format                  = m_oitWeightedRevealFormat;
-  //
-  //   VkAttachmentDescription colorAttachment = weightedColorAttachment;
-  //   colorAttachment.format                  = m_colorImage.getFormat();
-  //   colorAttachment.loadOp                  = VK_ATTACHMENT_LOAD_OP_LOAD;
-  //
-  //   VkAttachmentDescription depthAttachment = colorAttachment;
-  //   depthAttachment.format                  = m_depthImage.getFormat();
-  //   depthAttachment.initialLayout           = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-  //   depthAttachment.finalLayout             = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-  //
-  //   const std::array<VkAttachmentDescription, 4> allAttachments = {weightedColorAttachment, weightedRevealAttachment,
-  //                                                                  colorAttachment, depthAttachment};
-  //
-  //   std::array<VkSubpassDescription, 2> subpasses{};
-  //
-  //   // Subpass 0 - weighted textures & depth texture for testing
-  //   std::array<VkAttachmentReference, 2> subpass0ColorAttachments{};
-  //   subpass0ColorAttachments[0] = VkAttachmentReference{.attachment = 0, .layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
-  //   subpass0ColorAttachments[1] = VkAttachmentReference{.attachment = 1, .layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
-  //
-  //   // 3 is m_depthImage
-  //   const VkAttachmentReference depthAttachmentRef{.attachment = 3, .layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
-  //
-  //   subpasses[0] = VkSubpassDescription{
-  //       .pipelineBindPoint       = VK_PIPELINE_BIND_POINT_GRAPHICS,
-  //       .colorAttachmentCount    = static_cast<uint32_t>(subpass0ColorAttachments.size()),
-  //       .pColorAttachments       = subpass0ColorAttachments.data(),
-  //       .pDepthStencilAttachment = &depthAttachmentRef,
-  //   };
-  //
-  //   // Subpass 1
-  //   // Attachment 2 is m_colorImage
-  //   const VkAttachmentReference subpass1ColorAttachment{.attachment = 2, .layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
-  //
-  //   std::array<VkAttachmentReference, 2> subpass1InputAttachments{};
-  //   subpass1InputAttachments[0] = VkAttachmentReference{.attachment = 0, .layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
-  //   subpass1InputAttachments[1] = VkAttachmentReference{.attachment = 1, .layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
-  //
-  //   subpasses[1] = VkSubpassDescription{
-  //       .pipelineBindPoint    = VK_PIPELINE_BIND_POINT_GRAPHICS,
-  //       .inputAttachmentCount = static_cast<uint32_t>(subpass1InputAttachments.size()),
-  //       .pInputAttachments    = subpass1InputAttachments.data(),
-  //       .colorAttachmentCount = 1,
-  //       .pColorAttachments    = &subpass1ColorAttachment,
-  //   };
-  //
-  //   // Dependencies
-  //   std::array<VkSubpassDependency, 3> subpassDependencies{};
-  //   subpassDependencies[0] = VkSubpassDependency{
-  //       .srcSubpass    = VK_SUBPASS_EXTERNAL,
-  //       .dstSubpass    = 0,
-  //       .srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-  //       .dstStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-  //       .srcAccessMask = 0,
-  //       .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-  //   };
-  //   subpassDependencies[1] = VkSubpassDependency{
-  //       .srcSubpass    = 0,
-  //       .dstSubpass    = 1,
-  //       .srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-  //       .dstStageMask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-  //       .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-  //       .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
-  //   };
-  //   // Finally, we have a dependency at the end to allow the images to transition back to VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-  //   subpassDependencies[2] = VkSubpassDependency{
-  //       .srcSubpass    = 1,
-  //       .dstSubpass    = VK_SUBPASS_EXTERNAL,
-  //       .srcStageMask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-  //       .dstStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-  //       .srcAccessMask = VK_ACCESS_SHADER_READ_BIT,
-  //       .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-  //   };
-  //
-  //   // Finally, create the render pass
-  //   const VkRenderPassCreateInfo renderPassInfo{
-  //       .sType           = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
-  //       .attachmentCount = static_cast<uint32_t>(allAttachments.size()),
-  //       .pAttachments    = allAttachments.data(),
-  //       .subpassCount    = static_cast<uint32_t>(subpasses.size()),
-  //       .pSubpasses      = subpasses.data(),
-  //       .dependencyCount = static_cast<uint32_t>(subpassDependencies.size()),
-  //       .pDependencies   = subpassDependencies.data(),
-  //   };
-  //   NVVK_CHECK(vkCreateRenderPass(m_app->getDevice(), &renderPassInfo, nullptr, &m_renderPassWeighted));
-  //   NVVK_DBG_NAME(m_renderPassWeighted);
-  // }
-}
-
 void Sample::destroyShaderModules()
 {
   m_shaderCompiler.clear(m_app->getDevice());
@@ -698,7 +516,7 @@ void Sample::createGraphicsPipelines()
   // We always need the opaque pipeline:
   m_pipelines[+PassIndex::eOpaque] = createGraphicsPipeline("Opaque", m_vertexShaders[+VertexShaderIndex::eScene],
                                                             m_fragmentShaders[+PassIndex::eOpaque], BlendMode::NONE,
-                                                            true, false, m_renderPassColorDepthClear);
+                                                            true, false);
 
   const bool transparentDoubleSided = true;  // Iff transparent objects are double-sided
 
@@ -709,73 +527,73 @@ void Sample::createGraphicsPipelines()
       m_pipelines[+PassIndex::eSimpleColor] =
           createGraphicsPipeline("SimpleColor", m_vertexShaders[+VertexShaderIndex::eScene],
                                  m_fragmentShaders[+PassIndex::eSimpleColor], BlendMode::PREMULTIPLIED, true,
-                                 transparentDoubleSided, m_renderPassColorDepthClear);
+                                 transparentDoubleSided);
       m_pipelines[+PassIndex::eSimpleComposite] =
           createGraphicsPipeline("SimpleComposite", m_vertexShaders[+VertexShaderIndex::eFullScreenTriangle],
                                  m_fragmentShaders[+PassIndex::eSimpleComposite], BlendMode::PREMULTIPLIED, false,
-                                 transparentDoubleSided, m_renderPassColorDepthClear);
+                                 transparentDoubleSided);
       break;
     case OIT_LINKEDLIST:
       m_pipelines[+PassIndex::eLinkedListColor] =
           createGraphicsPipeline("LinkedListColor", m_vertexShaders[+VertexShaderIndex::eScene],
                                  m_fragmentShaders[+PassIndex::eLinkedListColor], BlendMode::PREMULTIPLIED, true,
-                                 transparentDoubleSided, m_renderPassColorDepthClear);
+                                 transparentDoubleSided);
       m_pipelines[+PassIndex::eLinkedListComposite] =
           createGraphicsPipeline("LinkedListComposite", m_vertexShaders[+VertexShaderIndex::eFullScreenTriangle],
                                  m_fragmentShaders[+PassIndex::eLinkedListComposite], BlendMode::PREMULTIPLIED, false,
-                                 transparentDoubleSided, m_renderPassColorDepthClear);
+                                 transparentDoubleSided);
       break;
     case OIT_LOOP:
       m_pipelines[+PassIndex::eLoopDepth] =
           createGraphicsPipeline("LoopDepth", m_vertexShaders[+VertexShaderIndex::eScene], m_fragmentShaders[+PassIndex::eLoopDepth],
-                                 BlendMode::PREMULTIPLIED, true, transparentDoubleSided, m_renderPassColorDepthClear);
+                                 BlendMode::PREMULTIPLIED, true, transparentDoubleSided);
       m_pipelines[+PassIndex::eLoopColor] =
           createGraphicsPipeline("LoopColor", m_vertexShaders[+VertexShaderIndex::eScene], m_fragmentShaders[+PassIndex::eLoopColor],
-                                 BlendMode::PREMULTIPLIED, true, transparentDoubleSided, m_renderPassColorDepthClear);
+                                 BlendMode::PREMULTIPLIED, true, transparentDoubleSided);
       m_pipelines[+PassIndex::eLoopComposite] =
           createGraphicsPipeline("LoopComposite", m_vertexShaders[+VertexShaderIndex::eFullScreenTriangle],
                                  m_fragmentShaders[+PassIndex::eLoopComposite], BlendMode::PREMULTIPLIED, false,
-                                 transparentDoubleSided, m_renderPassColorDepthClear);
+                                 transparentDoubleSided);
       break;
     case OIT_LOOP64:
       m_pipelines[+PassIndex::eLoop64Color] =
           createGraphicsPipeline("Loop64Color", m_vertexShaders[+VertexShaderIndex::eScene],
                                  m_fragmentShaders[+PassIndex::eLoop64Color], BlendMode::PREMULTIPLIED, true,
-                                 transparentDoubleSided, m_renderPassColorDepthClear);
+                                 transparentDoubleSided);
       m_pipelines[+PassIndex::eLoop64Composite] =
           createGraphicsPipeline("Loop64Composite", m_vertexShaders[+VertexShaderIndex::eFullScreenTriangle],
                                  m_fragmentShaders[+PassIndex::eLoop64Composite], BlendMode::PREMULTIPLIED, false,
-                                 transparentDoubleSided, m_renderPassColorDepthClear);
+                                 transparentDoubleSided);
       break;
     case OIT_INTERLOCK:
       m_pipelines[+PassIndex::eInterlockColor] =
           createGraphicsPipeline("InterlockColor", m_vertexShaders[+VertexShaderIndex::eScene],
                                  m_fragmentShaders[+PassIndex::eInterlockColor], BlendMode::PREMULTIPLIED, true,
-                                 transparentDoubleSided, m_renderPassColorDepthClear);
+                                 transparentDoubleSided);
       m_pipelines[+PassIndex::eInterlockComposite] =
           createGraphicsPipeline("InterlockComposite", m_vertexShaders[+VertexShaderIndex::eFullScreenTriangle],
                                  m_fragmentShaders[+PassIndex::eInterlockComposite], BlendMode::PREMULTIPLIED, false,
-                                 transparentDoubleSided, m_renderPassColorDepthClear);
+                                 transparentDoubleSided);
       break;
     case OIT_SPINLOCK:
       m_pipelines[+PassIndex::eSpinlockColor] =
           createGraphicsPipeline("InterlockColor", m_vertexShaders[+VertexShaderIndex::eScene],
                                  m_fragmentShaders[+PassIndex::eSpinlockColor], BlendMode::PREMULTIPLIED, true,
-                                 transparentDoubleSided, m_renderPassColorDepthClear);
+                                 transparentDoubleSided);
       m_pipelines[+PassIndex::eSpinlockComposite] =
           createGraphicsPipeline("InterlockComposite", m_vertexShaders[+VertexShaderIndex::eFullScreenTriangle],
                                  m_fragmentShaders[+PassIndex::eSpinlockComposite], BlendMode::PREMULTIPLIED, false,
-                                 transparentDoubleSided, m_renderPassColorDepthClear);
+                                 transparentDoubleSided);
       break;
     case OIT_WEIGHTED:
       m_pipelines[+PassIndex::eWeightedColor] =
           createGraphicsPipeline("WeightedColor", m_vertexShaders[+VertexShaderIndex::eScene],
                                  m_fragmentShaders[+PassIndex::eWeightedColor], BlendMode::WEIGHTED_COLOR, true,
-                                 transparentDoubleSided, m_renderPassWeighted, 0);
+                                 transparentDoubleSided);
       m_pipelines[+PassIndex::eWeightedComposite] =
           createGraphicsPipeline("WeightedComposite", m_vertexShaders[+VertexShaderIndex::eFullScreenTriangle],
                                  m_fragmentShaders[+PassIndex::eWeightedComposite], BlendMode::WEIGHTED_COMPOSITE,
-                                 false, transparentDoubleSided, m_renderPassWeighted, 1);
+                                 false, transparentDoubleSided);
       break;
   }
 }

--- a/oit.cpp
+++ b/oit.cpp
@@ -321,7 +321,7 @@ void Sample::updateAllDescriptorSets()
 
   const VkDescriptorImageInfo oitWeightedColorInfo = {.sampler     = VK_NULL_HANDLE,
                                                       .imageView   = m_oitWeightedColorImage.getView(),
-                                                      .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
+                                                      .imageLayout = VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR};
 
   VkDescriptorImageInfo oitWeightedRevealInfo = oitWeightedColorInfo;
   oitWeightedRevealInfo.imageView             = m_oitWeightedRevealImage.getView();

--- a/oit.cpp
+++ b/oit.cpp
@@ -213,7 +213,6 @@ void Sample::createFrameImages(VkCommandBuffer cmdBuffer)
                                   m_oitWeightedRevealFormat, bufferWidth, bufferHeight, 1, weightedUsages, m_state.msaa);
     NVVK_DBG_NAME(m_oitWeightedRevealImage.image.image);
     // Transition both of them to color attachments, which is the way they'll first be used:
-    // (see m_renderPassWeighted for reference)
     m_oitWeightedColorImage.transitionTo(cmdBuffer, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     m_oitWeightedRevealImage.transitionTo(cmdBuffer, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
   }
@@ -383,21 +382,6 @@ void Sample::updateAllDescriptorSets()
 
   // Now go ahead and update the descriptor sets!
   vkUpdateDescriptorSets(m_app->getDevice(), static_cast<uint32_t>(updates.size()), updates.data(), 0, nullptr);
-}
-
-void Sample::destroyRenderPasses()
-{
-  if(m_renderPassColorDepthClear != VK_NULL_HANDLE)
-  {
-    vkDestroyRenderPass(m_app->getDevice(), m_renderPassColorDepthClear, NULL);
-    m_renderPassColorDepthClear = VK_NULL_HANDLE;
-  }
-
-  if(m_renderPassWeighted != VK_NULL_HANDLE)
-  {
-    vkDestroyRenderPass(m_app->getDevice(), m_renderPassWeighted, NULL);
-    m_renderPassWeighted = VK_NULL_HANDLE;
-  }
 }
 
 void Sample::destroyShaderModules()

--- a/oit.cpp
+++ b/oit.cpp
@@ -409,64 +409,64 @@ void Sample::createRenderPasses()
   // beforehand. Both are in VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL.
   // We create this manually since (as of this writing) nvvk::createRenderPass
   // doesn't support multisampling.
-  {
-    std::array<VkAttachmentDescription, 2> attachments = {};  // Color attachment, depth attachment
-    // Color attachment
-    attachments[0] = VkAttachmentDescription{
-        .format         = m_colorImage.getFormat(),
-        .samples        = static_cast<VkSampleCountFlagBits>(m_state.msaa),
-        .loadOp         = VK_ATTACHMENT_LOAD_OP_CLEAR,
-        .storeOp        = VK_ATTACHMENT_STORE_OP_STORE,
-        .stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-        .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
-        .initialLayout  = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-        .finalLayout    = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-    };
-
-    // Color attachment reference
-    const VkAttachmentReference colorAttachmentRef{.attachment = 0, .layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
-
-    // Depth attachment
-    attachments[1]               = attachments[0];
-    attachments[1].format        = m_depthImage.getFormat();
-    attachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-    attachments[1].finalLayout   = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-
-    // Depth attachment reference
-    const VkAttachmentReference depthAttachmentRef{.attachment = 1, .layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
-
-    // 1 subpass
-    const VkSubpassDescription subpass{.pipelineBindPoint       = VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                       .colorAttachmentCount    = 1,
-                                       .pColorAttachments       = &colorAttachmentRef,
-                                       .pDepthStencilAttachment = &depthAttachmentRef};
-
-    // We only need to specify one dependency: Since the subpass has a barrier, the subpass will
-    // need a self-dependency. (There are implicit external dependencies that are automatically added.)
-    const VkSubpassDependency selfDependency{
-        .srcSubpass      = 0,
-        .dstSubpass      = 0,
-        .srcStageMask    = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-        .dstStageMask    = selfDependency.srcStageMask,
-        .srcAccessMask   = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT,
-        .dstAccessMask   = selfDependency.srcAccessMask,
-        .dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT  // Required, since we use framebuffer-space stages
-    };
-
-    // No dependency on external data
-    const VkRenderPassCreateInfo rpInfo{
-        .sType           = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
-        .attachmentCount = static_cast<uint32_t>(attachments.size()),
-        .pAttachments    = attachments.data(),
-        .subpassCount    = 1,
-        .pSubpasses      = &subpass,
-        .dependencyCount = 1,
-        .pDependencies   = &selfDependency,
-    };
-
-    NVVK_CHECK(vkCreateRenderPass(m_app->getDevice(), &rpInfo, NULL, &m_renderPassColorDepthClear));
-    NVVK_DBG_NAME(m_renderPassColorDepthClear);
-  }
+  // {
+  //   std::array<VkAttachmentDescription, 2> attachments = {};  // Color attachment, depth attachment
+  //   // Color attachment
+  //   attachments[0] = VkAttachmentDescription{
+  //       .format         = m_colorImage.getFormat(),
+  //       .samples        = static_cast<VkSampleCountFlagBits>(m_state.msaa),
+  //       .loadOp         = VK_ATTACHMENT_LOAD_OP_CLEAR,
+  //       .storeOp        = VK_ATTACHMENT_STORE_OP_STORE,
+  //       .stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+  //       .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+  //       .initialLayout  = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+  //       .finalLayout    = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+  //   };
+  //
+  //   // Color attachment reference
+  //   const VkAttachmentReference colorAttachmentRef{.attachment = 0, .layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+  //
+  //   // Depth attachment
+  //   attachments[1]               = attachments[0];
+  //   attachments[1].format        = m_depthImage.getFormat();
+  //   attachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+  //   attachments[1].finalLayout   = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+  //
+  //   // Depth attachment reference
+  //   const VkAttachmentReference depthAttachmentRef{.attachment = 1, .layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
+  //
+  //   // 1 subpass
+  //   const VkSubpassDescription subpass{.pipelineBindPoint       = VK_PIPELINE_BIND_POINT_GRAPHICS,
+  //                                      .colorAttachmentCount    = 1,
+  //                                      .pColorAttachments       = &colorAttachmentRef,
+  //                                      .pDepthStencilAttachment = &depthAttachmentRef};
+  //
+  //   // We only need to specify one dependency: Since the subpass has a barrier, the subpass will
+  //   // need a self-dependency. (There are implicit external dependencies that are automatically added.)
+  //   const VkSubpassDependency selfDependency{
+  //       .srcSubpass      = 0,
+  //       .dstSubpass      = 0,
+  //       .srcStageMask    = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+  //       .dstStageMask    = selfDependency.srcStageMask,
+  //       .srcAccessMask   = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT,
+  //       .dstAccessMask   = selfDependency.srcAccessMask,
+  //       .dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT  // Required, since we use framebuffer-space stages
+  //   };
+  //
+  //   // No dependency on external data
+  //   const VkRenderPassCreateInfo rpInfo{
+  //       .sType           = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+  //       .attachmentCount = static_cast<uint32_t>(attachments.size()),
+  //       .pAttachments    = attachments.data(),
+  //       .subpassCount    = 1,
+  //       .pSubpasses      = &subpass,
+  //       .dependencyCount = 1,
+  //       .pDependencies   = &selfDependency,
+  //   };
+  //
+  //   NVVK_CHECK(vkCreateRenderPass(m_app->getDevice(), &rpInfo, NULL, &m_renderPassColorDepthClear));
+  //   NVVK_DBG_NAME(m_renderPassColorDepthClear);
+  //}
 
   // m_renderPassWeighted
   // This render pass is used for Weighted, Blended Order-Independent
@@ -480,106 +480,106 @@ void Sample::createRenderPasses()
   // output attachment, and performs the WBOIT resolve step.
   // See https://www.saschawillems.de/blog/2018/07/19/vulkan-input-attachments-and-sub-passes/
   // for an example of a different type.
-  {
+  //{
     // Describe the attachments at the beginning and end of the render pass.
-    const VkAttachmentDescription weightedColorAttachment{.format  = m_oitWeightedColorFormat,
-                                                          .samples = static_cast<VkSampleCountFlagBits>(m_state.msaa),
-                                                          .loadOp  = VK_ATTACHMENT_LOAD_OP_CLEAR,
-                                                          .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
-                                                          .stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-                                                          .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
-                                                          .initialLayout  = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-                                                          .finalLayout    = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
-
-    VkAttachmentDescription weightedRevealAttachment = weightedColorAttachment;
-    weightedRevealAttachment.format                  = m_oitWeightedRevealFormat;
-
-    VkAttachmentDescription colorAttachment = weightedColorAttachment;
-    colorAttachment.format                  = m_colorImage.getFormat();
-    colorAttachment.loadOp                  = VK_ATTACHMENT_LOAD_OP_LOAD;
-
-    VkAttachmentDescription depthAttachment = colorAttachment;
-    depthAttachment.format                  = m_depthImage.getFormat();
-    depthAttachment.initialLayout           = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-    depthAttachment.finalLayout             = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-
-    const std::array<VkAttachmentDescription, 4> allAttachments = {weightedColorAttachment, weightedRevealAttachment,
-                                                                   colorAttachment, depthAttachment};
-
-    std::array<VkSubpassDescription, 2> subpasses{};
-
-    // Subpass 0 - weighted textures & depth texture for testing
-    std::array<VkAttachmentReference, 2> subpass0ColorAttachments{};
-    subpass0ColorAttachments[0] = VkAttachmentReference{.attachment = 0, .layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
-    subpass0ColorAttachments[1] = VkAttachmentReference{.attachment = 1, .layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
-
-    // 3 is m_depthImage
-    const VkAttachmentReference depthAttachmentRef{.attachment = 3, .layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
-
-    subpasses[0] = VkSubpassDescription{
-        .pipelineBindPoint       = VK_PIPELINE_BIND_POINT_GRAPHICS,
-        .colorAttachmentCount    = static_cast<uint32_t>(subpass0ColorAttachments.size()),
-        .pColorAttachments       = subpass0ColorAttachments.data(),
-        .pDepthStencilAttachment = &depthAttachmentRef,
-    };
-
-    // Subpass 1
-    // Attachment 2 is m_colorImage
-    const VkAttachmentReference subpass1ColorAttachment{.attachment = 2, .layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
-
-    std::array<VkAttachmentReference, 2> subpass1InputAttachments{};
-    subpass1InputAttachments[0] = VkAttachmentReference{.attachment = 0, .layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
-    subpass1InputAttachments[1] = VkAttachmentReference{.attachment = 1, .layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
-
-    subpasses[1] = VkSubpassDescription{
-        .pipelineBindPoint    = VK_PIPELINE_BIND_POINT_GRAPHICS,
-        .inputAttachmentCount = static_cast<uint32_t>(subpass1InputAttachments.size()),
-        .pInputAttachments    = subpass1InputAttachments.data(),
-        .colorAttachmentCount = 1,
-        .pColorAttachments    = &subpass1ColorAttachment,
-    };
-
-    // Dependencies
-    std::array<VkSubpassDependency, 3> subpassDependencies{};
-    subpassDependencies[0] = VkSubpassDependency{
-        .srcSubpass    = VK_SUBPASS_EXTERNAL,
-        .dstSubpass    = 0,
-        .srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-        .dstStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-        .srcAccessMask = 0,
-        .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-    };
-    subpassDependencies[1] = VkSubpassDependency{
-        .srcSubpass    = 0,
-        .dstSubpass    = 1,
-        .srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-        .dstStageMask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-        .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-        .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
-    };
-    // Finally, we have a dependency at the end to allow the images to transition back to VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-    subpassDependencies[2] = VkSubpassDependency{
-        .srcSubpass    = 1,
-        .dstSubpass    = VK_SUBPASS_EXTERNAL,
-        .srcStageMask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-        .dstStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-        .srcAccessMask = VK_ACCESS_SHADER_READ_BIT,
-        .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-    };
-
-    // Finally, create the render pass
-    const VkRenderPassCreateInfo renderPassInfo{
-        .sType           = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
-        .attachmentCount = static_cast<uint32_t>(allAttachments.size()),
-        .pAttachments    = allAttachments.data(),
-        .subpassCount    = static_cast<uint32_t>(subpasses.size()),
-        .pSubpasses      = subpasses.data(),
-        .dependencyCount = static_cast<uint32_t>(subpassDependencies.size()),
-        .pDependencies   = subpassDependencies.data(),
-    };
-    NVVK_CHECK(vkCreateRenderPass(m_app->getDevice(), &renderPassInfo, nullptr, &m_renderPassWeighted));
-    NVVK_DBG_NAME(m_renderPassWeighted);
-  }
+  //   const VkAttachmentDescription weightedColorAttachment{.format  = m_oitWeightedColorFormat,
+  //                                                         .samples = static_cast<VkSampleCountFlagBits>(m_state.msaa),
+  //                                                         .loadOp  = VK_ATTACHMENT_LOAD_OP_CLEAR,
+  //                                                         .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+  //                                                         .stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+  //                                                         .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+  //                                                         .initialLayout  = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+  //                                                         .finalLayout    = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+  //
+  //   VkAttachmentDescription weightedRevealAttachment = weightedColorAttachment;
+  //   weightedRevealAttachment.format                  = m_oitWeightedRevealFormat;
+  //
+  //   VkAttachmentDescription colorAttachment = weightedColorAttachment;
+  //   colorAttachment.format                  = m_colorImage.getFormat();
+  //   colorAttachment.loadOp                  = VK_ATTACHMENT_LOAD_OP_LOAD;
+  //
+  //   VkAttachmentDescription depthAttachment = colorAttachment;
+  //   depthAttachment.format                  = m_depthImage.getFormat();
+  //   depthAttachment.initialLayout           = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+  //   depthAttachment.finalLayout             = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+  //
+  //   const std::array<VkAttachmentDescription, 4> allAttachments = {weightedColorAttachment, weightedRevealAttachment,
+  //                                                                  colorAttachment, depthAttachment};
+  //
+  //   std::array<VkSubpassDescription, 2> subpasses{};
+  //
+  //   // Subpass 0 - weighted textures & depth texture for testing
+  //   std::array<VkAttachmentReference, 2> subpass0ColorAttachments{};
+  //   subpass0ColorAttachments[0] = VkAttachmentReference{.attachment = 0, .layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+  //   subpass0ColorAttachments[1] = VkAttachmentReference{.attachment = 1, .layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+  //
+  //   // 3 is m_depthImage
+  //   const VkAttachmentReference depthAttachmentRef{.attachment = 3, .layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
+  //
+  //   subpasses[0] = VkSubpassDescription{
+  //       .pipelineBindPoint       = VK_PIPELINE_BIND_POINT_GRAPHICS,
+  //       .colorAttachmentCount    = static_cast<uint32_t>(subpass0ColorAttachments.size()),
+  //       .pColorAttachments       = subpass0ColorAttachments.data(),
+  //       .pDepthStencilAttachment = &depthAttachmentRef,
+  //   };
+  //
+  //   // Subpass 1
+  //   // Attachment 2 is m_colorImage
+  //   const VkAttachmentReference subpass1ColorAttachment{.attachment = 2, .layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+  //
+  //   std::array<VkAttachmentReference, 2> subpass1InputAttachments{};
+  //   subpass1InputAttachments[0] = VkAttachmentReference{.attachment = 0, .layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
+  //   subpass1InputAttachments[1] = VkAttachmentReference{.attachment = 1, .layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
+  //
+  //   subpasses[1] = VkSubpassDescription{
+  //       .pipelineBindPoint    = VK_PIPELINE_BIND_POINT_GRAPHICS,
+  //       .inputAttachmentCount = static_cast<uint32_t>(subpass1InputAttachments.size()),
+  //       .pInputAttachments    = subpass1InputAttachments.data(),
+  //       .colorAttachmentCount = 1,
+  //       .pColorAttachments    = &subpass1ColorAttachment,
+  //   };
+  //
+  //   // Dependencies
+  //   std::array<VkSubpassDependency, 3> subpassDependencies{};
+  //   subpassDependencies[0] = VkSubpassDependency{
+  //       .srcSubpass    = VK_SUBPASS_EXTERNAL,
+  //       .dstSubpass    = 0,
+  //       .srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+  //       .dstStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+  //       .srcAccessMask = 0,
+  //       .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+  //   };
+  //   subpassDependencies[1] = VkSubpassDependency{
+  //       .srcSubpass    = 0,
+  //       .dstSubpass    = 1,
+  //       .srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+  //       .dstStageMask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+  //       .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+  //       .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+  //   };
+  //   // Finally, we have a dependency at the end to allow the images to transition back to VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
+  //   subpassDependencies[2] = VkSubpassDependency{
+  //       .srcSubpass    = 1,
+  //       .dstSubpass    = VK_SUBPASS_EXTERNAL,
+  //       .srcStageMask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+  //       .dstStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+  //       .srcAccessMask = VK_ACCESS_SHADER_READ_BIT,
+  //       .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+  //   };
+  //
+  //   // Finally, create the render pass
+  //   const VkRenderPassCreateInfo renderPassInfo{
+  //       .sType           = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+  //       .attachmentCount = static_cast<uint32_t>(allAttachments.size()),
+  //       .pAttachments    = allAttachments.data(),
+  //       .subpassCount    = static_cast<uint32_t>(subpasses.size()),
+  //       .pSubpasses      = subpasses.data(),
+  //       .dependencyCount = static_cast<uint32_t>(subpassDependencies.size()),
+  //       .pDependencies   = subpassDependencies.data(),
+  //   };
+  //   NVVK_CHECK(vkCreateRenderPass(m_app->getDevice(), &renderPassInfo, nullptr, &m_renderPassWeighted));
+  //   NVVK_DBG_NAME(m_renderPassWeighted);
+  // }
 }
 
 void Sample::destroyShaderModules()

--- a/oit.h
+++ b/oit.h
@@ -175,9 +175,7 @@ public:
   // We have one of these per frame since the CPU can be uploading to one while
   // the other is being used for rendering.
   std::vector<nvvk::Buffer> m_uniformBuffers;
-  // We only need one of each of these resources, since only one draw operation will run at once.
-  VkFramebuffer m_mainColorDepthFramebuffer = VK_NULL_HANDLE;
-  VkFramebuffer m_weightedFramebuffer       = VK_NULL_HANDLE;
+
   ImageAndView  m_depthImage;
   ImageAndView  m_colorImage;
   BufferAndView m_oitABuffer;
@@ -422,5 +420,5 @@ public:
   // and is an approximate technique; instead, it uses two intermediate render
   // targets, which we implement using a render pass (see the creation of the
   // render pass for more information as to how that's set up).
-  void drawTransparentWeighted(VkCommandBuffer& cmdBuffer, int numObjects);
+  void drawTransparentWeighted(VkCommandBuffer& cmdBuffer , int numObjects);
 };

--- a/oit.h
+++ b/oit.h
@@ -185,6 +185,27 @@ public:
   ImageAndView  m_oitCounterImage;
   ImageAndView  m_oitWeightedColorImage;
   ImageAndView  m_oitWeightedRevealImage;
+
+  //Mapping is Array indices to shader layout  
+  std::array<uint32_t, 3>             color_attachment_locations = {VK_ATTACHMENT_UNUSED, 0, 1, };
+  VkRenderingAttachmentLocationInfo   locationInfo{VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO_KHR,
+                                                    nullptr,
+                                                    static_cast<uint32_t>(color_attachment_locations.size()),
+                            color_attachment_locations.data()};
+
+  std::array<uint32_t, 3>             reset_color_attachment_locations = {0, VK_ATTACHMENT_UNUSED, VK_ATTACHMENT_UNUSED};
+  VkRenderingAttachmentLocationInfo   resetLocationInfo{VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO_KHR,
+                                                    nullptr,
+                                                    static_cast<uint32_t>(reset_color_attachment_locations.size()),
+                            reset_color_attachment_locations.data()};
+
+  std::array<uint32_t, 3>             color_attachment_input_indices{VK_ATTACHMENT_UNUSED, 1, 2  };
+  VkRenderingInputAttachmentIndexInfo rendering_attachment_index_info{VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR,
+                                                                      nullptr,
+                                                                      static_cast<uint32_t>(color_attachment_input_indices.size()),
+                                                                      color_attachment_input_indices.data()};
+
+
   // Depending on the MSAA settings and resolution, we may want to downsample
   // to a 1 sample per screen pixel texture:
   ImageAndView m_downsampleImage;

--- a/oit.h
+++ b/oit.h
@@ -308,9 +308,7 @@ public:
   // Descriptors
   nvvk::DescriptorPack m_descriptorPack;
   VkPipelineLayout     m_pipelineLayout = VK_NULL_HANDLE;
-  // Render passes
-  VkRenderPass m_renderPassColorDepthClear = VK_NULL_HANDLE;
-  VkRenderPass m_renderPassWeighted        = VK_NULL_HANDLE;
+
   // Graphics pipelines (organized by the algorithms that use them)
   std::array<VkPipeline, size_t(PassIndex::eCount)> m_pipelines{};
 
@@ -414,15 +412,6 @@ public:
   // This needs to be called whenever our buffers change. This will basically
   // cause VkCmdBindDescriptorSets to bind all of the textures we need at once.
   void updateAllDescriptorSets();
-
-  // Device must not be using resource when called.
-  void destroyRenderPasses();
-
-  // Device must not be using resource when called.
-  void destroyFramebuffers();
-
-  // Device must not be using resource when called.
-  void createFramebuffers();
 
   // Device must not be using resource when called.
   void destroyShaderModules();

--- a/oit.h
+++ b/oit.h
@@ -186,25 +186,107 @@ public:
   ImageAndView  m_oitWeightedColorImage;
   ImageAndView  m_oitWeightedRevealImage;
 
-  //Mapping is Array indices to shader layout  
-  std::array<uint32_t, 3>             color_attachment_locations = {VK_ATTACHMENT_UNUSED, 0, 1, };
-  VkRenderingAttachmentLocationInfo   locationInfo{VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO_KHR,
-                                                    nullptr,
-                                                    static_cast<uint32_t>(color_attachment_locations.size()),
-                            color_attachment_locations.data()};
+  /////////////////////////////////////////////////////////////////////////////
+  //Weighted OIT color attachment mappings
+  /*
+   * Specifies the locations of color attachments in a Vulkan render pass.
+   *
+   * These arrays contain indices corresponding to the attachment points in the
+   * color attachments array which can be found in drawTransparentWeighted().
+   *
+   * - `VK_ATTACHMENT_UNUSED` indicates that the corresponding color output is not used.
+   * - Other values represent valid attachment indices.
+   *
+   * The size of the array represents the maximum number of color attachments
+   * considered for this particular configuration.
+   */
+  /////////////////////////////////////////////////////////////////////////////
 
-  std::array<uint32_t, 3>             reset_color_attachment_locations = {0, VK_ATTACHMENT_UNUSED, VK_ATTACHMENT_UNUSED};
-  VkRenderingAttachmentLocationInfo   resetLocationInfo{VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO_KHR,
-                                                    nullptr,
-                                                    static_cast<uint32_t>(reset_color_attachment_locations.size()),
-                            reset_color_attachment_locations.data()};
 
-  std::array<uint32_t, 3>             color_attachment_input_indices{VK_ATTACHMENT_UNUSED, 1, 2  };
-  VkRenderingInputAttachmentIndexInfo rendering_attachment_index_info{VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR,
+  /*
+   * VkRenderingAttachmentLocationInfo is used to decide which color attachment will receive which shader output
+   * eg [image 1 in the color attachments array will receive the data written by layout(location = 1) out float outReveal]
+   * In other words, the array index is used to decide how shader outputs map to color attachments.
+   * This array is created here and needs to be passed to the pipeline at construction time and also needs to be called as part of cmd buffer recording.
+   * See createGraphicsPipeline and drawTransparentWeighted() for implementations of these.
+  */
+
+  //WBOIT uses two passes. We need the first pass to write exclusively to the accumulutation and revealage image attachments and ignore the main color pass
+  //Index 0 of the color attachments array maps to an unused output.
+  //Index 1 of the color attachments array maps to shader layout (0) -> color
+  //Index 2 of the color attachmnets array maps to shader layout (1) -> alpha
+  std::array<uint32_t, 3>             m_wboitColorAttachmentLocations = {VK_ATTACHMENT_UNUSED, 0, 1, };
+  VkRenderingAttachmentLocationInfo   m_wboitColorAttachmentLocationInfo{VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO_KHR,
+                                                    nullptr,
+                                                    static_cast<uint32_t>(m_wboitColorAttachmentLocations.size()),
+                            m_wboitColorAttachmentLocations.data()};
+
+  //These are used in the composite
+  //Same explanation applies here too as the previous array. The only difference is this is used to reset the shader write order back to default
+  std::array<uint32_t, 3>             m_wboitCompositeResetAttachmentLocations = {0, VK_ATTACHMENT_UNUSED, VK_ATTACHMENT_UNUSED};
+  VkRenderingAttachmentLocationInfo   m_wboitCompositeResetAttachmentLocationsInfo{VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO_KHR,
+                                                    nullptr,
+                                                    static_cast<uint32_t>(m_wboitCompositeResetAttachmentLocations.size()),
+                            m_wboitCompositeResetAttachmentLocations.data()};
+
+  //This is used to decide the shader input read order. This maps which color attachment from the color attachments array is read by which shader input
+  std::array<uint32_t, 3>             m_wboitCompositeAttachmentInputIndices{VK_ATTACHMENT_UNUSED, 1, 2  };
+  VkRenderingInputAttachmentIndexInfo m_wboitCompositeAttachmentInputIndicesInfo{VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR,
                                                                       nullptr,
-                                                                      static_cast<uint32_t>(color_attachment_input_indices.size()),
-                                                                      color_attachment_input_indices.data()};
+                                                                      static_cast<uint32_t>(m_wboitCompositeAttachmentInputIndices.size()),
+                                                                      m_wboitCompositeAttachmentInputIndices.data()};
 
+  //Color attachments that will be used for both passes of WBOIT
+  std::array<VkRenderingAttachmentInfo, 3> colorInfo = {{
+    // 0: Main Color Output (Load existing opaque geometry)
+    {
+      .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+      .pNext = nullptr,
+      .imageView = m_colorImage.getView(),
+      .imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+      .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
+      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+   },
+    // 1: Weighted Color Output
+    {
+      .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+      .pNext = nullptr,
+      .imageView = m_oitWeightedColorImage.getView(),
+      .imageLayout = VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR,
+      .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+      .clearValue = VkClearColorValue{.float32 = {0.0f, 0.0f, 0.0f, 0.0f}},
+    },
+    // 2: Weighted Reveal Output
+    {
+      .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+      .pNext = nullptr,
+      .imageView = m_oitWeightedRevealImage.getView(),
+      .imageLayout = VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR,
+      .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+      .clearValue = VkClearColorValue{.float32 = {1.0f, 0.0f, 0.0f, 0.0f}} // Reveal starts at 1.0,
+   },
+  }};
+
+  VkRenderingAttachmentInfo depthInfo = {
+    .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+    .pNext = nullptr,
+    .imageView = m_depthImage.getView(),
+    .imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+    .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
+    .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+  };
+
+  VkRenderingInfo renderInfo = {
+    .sType = VK_STRUCTURE_TYPE_RENDERING_INFO,
+    .pNext = nullptr,
+    .renderArea = {.extent = {.width = m_colorImage.getWidth(), .height = m_colorImage.getHeight()}},
+    .layerCount = 1,
+    .colorAttachmentCount = static_cast<uint32_t>(colorInfo.size()),
+    .pColorAttachments = colorInfo.data(),
+    .pDepthAttachment  = &depthInfo,
+  };
 
   // Depending on the MSAA settings and resolution, we may want to downsample
   // to a 1 sample per screen pixel texture:
@@ -414,7 +496,7 @@ public:
 
   // Draws the first numObjects objects using the two-pass depth sorting OIT
   // method. Assumes that the right render pass has already been started, and
-  // that the index and vertex buffers for the mesh and drescriptors are already
+  // that the index and vertex buffers for the mesh and descriptors are already
   // good to go.
   void drawTransparentLoop(VkCommandBuffer& cmdBuffer, int numObjects);
 
@@ -422,7 +504,7 @@ public:
 
   // A variant of OIT_LOOP that uses one less draw pass when the GPU supports
   // 64-bit atomics. Assumes that the right render pass has already been started, and
-  // that the index and vertex buffers for the mesh and drescriptors are already
+  // that the index and vertex buffers for the mesh and descriptors are already
   // good to go.
   void drawTransparentLoop64(VkCommandBuffer& cmdBuffer, int numObjects);
 

--- a/oit.h
+++ b/oit.h
@@ -63,7 +63,7 @@ enum class BlendMode
 // These are initially set to one of the best-looking settings.
 struct State
 {
-  uint32_t algorithm                     = OIT_SPINLOCK;
+  uint32_t algorithm                     = OIT_WEIGHTED;
   uint32_t oitLayers                     = 8;
   int32_t  linkedListAllocatedPerElement = 10;
   int32_t  percentTransparent            = 100;

--- a/oit.h
+++ b/oit.h
@@ -63,7 +63,7 @@ enum class BlendMode
 // These are initially set to one of the best-looking settings.
 struct State
 {
-  uint32_t algorithm                     = OIT_WEIGHTED;
+  uint32_t algorithm                     = OIT_SPINLOCK;
   uint32_t oitLayers                     = 8;
   int32_t  linkedListAllocatedPerElement = 10;
   int32_t  percentTransparent            = 100;
@@ -214,7 +214,7 @@ public:
   //WBOIT uses two passes. We need the first pass to write exclusively to the accumulutation and revealage image attachments and ignore the main color pass
   //Index 0 of the color attachments array maps to an unused output.
   //Index 1 of the color attachments array maps to shader layout (0) -> color
-  //Index 2 of the color attachmnets array maps to shader layout (1) -> alpha
+  //Index 2 of the color attachments array maps to shader layout (1) -> alpha
   std::array<uint32_t, 3>             m_wboitColorAttachmentLocations = {VK_ATTACHMENT_UNUSED, 0, 1, };
   VkRenderingAttachmentLocationInfo   m_wboitColorAttachmentLocationInfo{VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO_KHR,
                                                     nullptr,

--- a/oit.h
+++ b/oit.h
@@ -236,58 +236,6 @@ public:
                                                                       static_cast<uint32_t>(m_wboitCompositeAttachmentInputIndices.size()),
                                                                       m_wboitCompositeAttachmentInputIndices.data()};
 
-  //Color attachments that will be used for both passes of WBOIT
-  std::array<VkRenderingAttachmentInfo, 3> colorInfo = {{
-    // 0: Main Color Output (Load existing opaque geometry)
-    {
-      .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
-      .pNext = nullptr,
-      .imageView = m_colorImage.getView(),
-      .imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-      .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
-      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
-   },
-    // 1: Weighted Color Output
-    {
-      .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
-      .pNext = nullptr,
-      .imageView = m_oitWeightedColorImage.getView(),
-      .imageLayout = VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR,
-      .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
-      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
-      .clearValue = VkClearColorValue{.float32 = {0.0f, 0.0f, 0.0f, 0.0f}},
-    },
-    // 2: Weighted Reveal Output
-    {
-      .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
-      .pNext = nullptr,
-      .imageView = m_oitWeightedRevealImage.getView(),
-      .imageLayout = VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR,
-      .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
-      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
-      .clearValue = VkClearColorValue{.float32 = {1.0f, 0.0f, 0.0f, 0.0f}} // Reveal starts at 1.0,
-   },
-  }};
-
-  VkRenderingAttachmentInfo depthInfo = {
-    .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
-    .pNext = nullptr,
-    .imageView = m_depthImage.getView(),
-    .imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
-    .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
-    .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
-  };
-
-  VkRenderingInfo renderInfo = {
-    .sType = VK_STRUCTURE_TYPE_RENDERING_INFO,
-    .pNext = nullptr,
-    .renderArea = {.extent = {.width = m_colorImage.getWidth(), .height = m_colorImage.getHeight()}},
-    .layerCount = 1,
-    .colorAttachmentCount = static_cast<uint32_t>(colorInfo.size()),
-    .pColorAttachments = colorInfo.data(),
-    .pDepthAttachment  = &depthInfo,
-  };
-
   // Depending on the MSAA settings and resolution, we may want to downsample
   // to a 1 sample per screen pixel texture:
   ImageAndView m_downsampleImage;

--- a/oit.h
+++ b/oit.h
@@ -418,9 +418,6 @@ public:
   // Device must not be using resource when called.
   void destroyRenderPasses();
 
-  // Creates or recreates all render passes.
-  void createRenderPasses();
-
   // Device must not be using resource when called.
   void destroyFramebuffers();
 
@@ -457,9 +454,7 @@ public:
                                     const VkShaderModule fragShaderModule,
                                     BlendMode            blendMode,
                                     bool                 usesVertexInput,
-                                    bool                 isDoubleSided,
-                                    VkRenderPass         renderPass,
-                                    uint32_t             subpass = 0);
+                                    bool                 isDoubleSided);
 
   /////////////////////////////////////////////////////////////////////////////
   // Main rendering logic                                                    //

--- a/oitRender.cpp
+++ b/oitRender.cpp
@@ -480,7 +480,16 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
   clearValues[1].color = VkClearColorValue{.float32 = {1.0f, 0.0f, 0.0f, 0.0f}}; // Reveal starts at 1.0
 
   std::array<VkRenderingAttachmentInfo, 3> colorInfo = {{
-    // 0: Weighted Color Output
+    // 0: Main Color Output (Load existing opaque geometry)
+    {
+      .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+      .pNext = nullptr,
+      .imageView = m_colorImage.getView(),
+      .imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+      .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
+      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+   },
+    // 1: Weighted Color Output
     {
       .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
       .pNext = nullptr,
@@ -490,7 +499,7 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
       .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
       .clearValue = clearValues[0],
     },
-    // 1: Weighted Reveal Output
+    // 2: Weighted Reveal Output
     {
       .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
       .pNext = nullptr,
@@ -500,15 +509,6 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
       .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
       .clearValue = clearValues[1],
    },
-   // 2: Main Color Output (Load existing opaque geometry)
-   {
-      .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
-      .pNext = nullptr,
-      .imageView = m_colorImage.getView(),
-      .imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-      .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
-      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
-   }
   }};
 
   VkRenderingAttachmentInfo depthInfo = {
@@ -532,17 +532,12 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
 
   vkCmdBeginRendering(cmd, &renderInfo);
 
+  //vkCmdSetRenderingInputAttachmentIndices(cmd, &rendering_attachment_index_info);
   // --- SUBPASS 1: COLOR ACCUMULATION ---
   {
-    VkRenderingAttachmentLocationInfoKHR locationInfo{VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO_KHR};
-    locationInfo.colorAttachmentCount = 3;
-
-    // Shader writes output 0 -> Attachment 0, output 1 -> Attachment 1. Skip Attachment 2.
-    uint32_t colorLocations[3] = {0, 1, VK_ATTACHMENT_UNUSED};
-    locationInfo.pColorAttachmentLocations = colorLocations;
-    //vkCmdSetRenderingAttachmentLocationsKHR(cmd, &locationInfo);
-
+    //For first pass, write to images 1 and 2
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipelines[+PassIndex::eWeightedColor]);
+    vkCmdSetRenderingAttachmentLocations(cmd, &locationInfo);
     vkCmdDrawIndexed(cmd, numObjects * m_objectTriangleIndices, 1, 0, 0, 0);
   }
 
@@ -564,22 +559,10 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
 
   // --- SUBPASS 2: COMPOSITE ---
   {
-    VkRenderingAttachmentLocationInfoKHR locationInfo{VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO_KHR};
-    locationInfo.colorAttachmentCount = 3;
-
-    // Shader writes output 0 -> Attachment 2. Skip Attachments 0 & 1.
-    uint32_t compositeLocations[3] = {VK_ATTACHMENT_UNUSED, VK_ATTACHMENT_UNUSED, 0};
-    locationInfo.pColorAttachmentLocations = compositeLocations;
-    //vkCmdSetRenderingAttachmentLocationsKHR(cmd, &locationInfo);
-
-    // Map shader input_attachment_index 0 -> Attachment 0, index 1 -> Attachment 1
-    VkRenderingInputAttachmentIndexInfoKHR inputInfo{VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR};
-    inputInfo.colorAttachmentCount = 3;
-    uint32_t inputIndices[3] = {VK_ATTACHMENT_UNUSED, 1, 0 };
-    inputInfo.pColorAttachmentInputIndices = inputIndices;
-    //vkCmdSetRenderingInputAttachmentIndices(cmd, &inputInfo);
-
+    //Only read last two entries
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipelines[+PassIndex::eWeightedComposite]);
+    vkCmdSetRenderingAttachmentLocations(cmd, &resetLocationInfo);
+    vkCmdSetRenderingInputAttachmentIndices(cmd, &rendering_attachment_index_info);
     vkCmdDraw(cmd, 3, 1, 0, 0);
   }
 }

--- a/oitRender.cpp
+++ b/oitRender.cpp
@@ -419,107 +419,140 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
 {
   // Swap out the render pass for WBOIT's render pass
   //vkCmdEndRenderPass(cmd);
+  // End the opaque rendering block
   vkCmdEndRendering(cmd);
 
   auto section = m_profilerGPU.cmdFrameSection(cmd, "WeightedBlendedOIT");
 
-  // Transition the color image to work as an attachment
   m_colorImage.transitionTo(cmd, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+  m_depthImage.transitionTo(cmd, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+  // m_oitWeightedColorImage.transitionTo(cmd, VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR);
+  // m_oitWeightedRevealImage.transitionTo(cmd, VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR);
+
+  //m_oitWeightedColorImage layout transition
+  VkImageMemoryBarrier2KHR imageMemoryBarrierColorImage{};
+  imageMemoryBarrierColorImage.sType            = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2_KHR;
+  imageMemoryBarrierColorImage.srcStageMask     = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR;
+  imageMemoryBarrierColorImage.dstStageMask     = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR;
+  imageMemoryBarrierColorImage.dstAccessMask    = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT_KHR;
+  imageMemoryBarrierColorImage.oldLayout        = VK_IMAGE_LAYOUT_UNDEFINED;
+  imageMemoryBarrierColorImage.newLayout        = VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR;
+  imageMemoryBarrierColorImage.subresourceRange = {
+    .aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT,
+    .baseMipLevel   = 0,
+    .levelCount     = 1,
+    .baseArrayLayer = 0,
+    .layerCount     = 1
+  };
+  imageMemoryBarrierColorImage.image            = m_oitWeightedColorImage.image.image;
+
+  VkDependencyInfoKHR dependencyInfoColorImage{};
+  dependencyInfoColorImage.sType                   = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR;
+  dependencyInfoColorImage.imageMemoryBarrierCount = 1;
+  dependencyInfoColorImage.pImageMemoryBarriers    = &imageMemoryBarrierColorImage;
+  vkCmdPipelineBarrier2(cmd, &dependencyInfoColorImage);
+
+  //m_oitWeightedRevealImage layout transition
+  VkImageMemoryBarrier2KHR imageMemoryBarrierRevealageImage{};
+  imageMemoryBarrierRevealageImage.sType            = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2_KHR;
+  imageMemoryBarrierRevealageImage.srcStageMask     = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR;
+  imageMemoryBarrierRevealageImage.dstStageMask     = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR;
+  imageMemoryBarrierRevealageImage.dstAccessMask    = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT_KHR;
+  imageMemoryBarrierRevealageImage.oldLayout        = VK_IMAGE_LAYOUT_UNDEFINED;
+  imageMemoryBarrierRevealageImage.newLayout        = VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR;
+  imageMemoryBarrierRevealageImage.subresourceRange ={
+      .aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT,
+      .baseMipLevel   = 0,
+      .levelCount     = 1,
+      .baseArrayLayer = 0,
+      .layerCount     = 1
+    };
+  imageMemoryBarrierRevealageImage.image            = m_oitWeightedRevealImage.image.image;
+
+  VkDependencyInfoKHR dependencyInfoRevealageImage{};
+  dependencyInfoColorImage.sType                   = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR;
+  dependencyInfoColorImage.imageMemoryBarrierCount = 1;
+  dependencyInfoColorImage.pImageMemoryBarriers    = &imageMemoryBarrierRevealageImage;
+  vkCmdPipelineBarrier2(cmd, &dependencyInfoColorImage);
 
   std::array<VkClearValue, 2> clearValues;
   clearValues[0].color = VkClearColorValue{.float32 = {0.0f, 0.0f, 0.0f, 0.0f}};
-  // Initially, all pixels show through all the way (reveal = 100%)
-  clearValues[1].color = VkClearColorValue{.float32 = {1.0f}};
+  clearValues[1].color = VkClearColorValue{.float32 = {1.0f, 0.0f, 0.0f, 0.0f}}; // Reveal starts at 1.0
 
-  std::array<VkRenderingAttachmentInfo,3> colorInfo =
-  {{
-    //Image 0
+  std::array<VkRenderingAttachmentInfo, 3> colorInfo = {{
+    // 0: Weighted Color Output
     {
       .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
       .pNext = nullptr,
       .imageView = m_oitWeightedColorImage.getView(),
-      .imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+      .imageLayout = VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR,
       .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
       .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
       .clearValue = clearValues[0],
     },
-
-    //Image 1
+    // 1: Weighted Reveal Output
     {
       .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
       .pNext = nullptr,
       .imageView = m_oitWeightedRevealImage.getView(),
-      .imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+      .imageLayout = VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR,
       .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
       .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
       .clearValue = clearValues[1],
    },
-
-    //Frame image
-    {
+   // 2: Main Color Output (Load existing opaque geometry)
+   {
       .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
       .pNext = nullptr,
       .imageView = m_colorImage.getView(),
       .imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
       .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
       .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
-      .clearValue = clearValues[0],
-    }
+   }
   }};
 
-  // const VkRenderPassBeginInfo renderPassInfo{.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
-  //                                            .renderPass      = m_renderPassWeighted,
-  //                                            .framebuffer     = m_weightedFramebuffer,
-  //                                            .renderArea      = {.extent = {.width  = m_oitWeightedColorImage.getWidth(),
-  //                                                                           .height = m_oitWeightedColorImage.getHeight()}},
-  //                                            .clearValueCount = uint32_t(clearValues.size()),
-  //                                            .pClearValues    = clearValues.data()};
-
-  //Depth Image
-  VkRenderingAttachmentInfo depthInfo =
-  {
+  VkRenderingAttachmentInfo depthInfo = {
     .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
     .pNext = nullptr,
     .imageView = m_depthImage.getView(),
     .imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
     .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
     .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
-    .clearValue = clearValues[1],
   };
 
-
-  VkRenderingInfo renderInfo =
-  {
+  VkRenderingInfo renderInfo = {
     .sType = VK_STRUCTURE_TYPE_RENDERING_INFO,
     .pNext = nullptr,
-    .renderArea = {.extent = {.width  = m_colorImage.getWidth(), .height = m_colorImage.getHeight()}},
+    .renderArea = {.extent = {.width = m_colorImage.getWidth(), .height = m_colorImage.getHeight()}},
     .layerCount = 1,
-    .colorAttachmentCount = (uint32_t) colorInfo.size(),
+    .colorAttachmentCount = static_cast<uint32_t>(colorInfo.size()),
     .pColorAttachments = colorInfo.data(),
     .pDepthAttachment  = &depthInfo,
   };
 
-  //vkCmdBeginRenderPass(cmd, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
   vkCmdBeginRendering(cmd, &renderInfo);
 
-  // COLOR PASS
-  // Computes the weighted sum and reveal factor.
+  // --- SUBPASS 1: COLOR ACCUMULATION ---
   {
+    VkRenderingAttachmentLocationInfoKHR locationInfo{VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO_KHR};
+    locationInfo.colorAttachmentCount = 3;
+
+    // Shader writes output 0 -> Attachment 0, output 1 -> Attachment 1. Skip Attachment 2.
+    uint32_t colorLocations[3] = {0, 1, VK_ATTACHMENT_UNUSED};
+    locationInfo.pColorAttachmentLocations = colorLocations;
+    //vkCmdSetRenderingAttachmentLocationsKHR(cmd, &locationInfo);
+
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipelines[+PassIndex::eWeightedColor]);
-    // Draw all objects
     vkCmdDrawIndexed(cmd, numObjects * m_objectTriangleIndices, 1, 0, 0, 0);
   }
 
-  // Move to the next subpass
-  //vkCmdNextSubpass(cmd, VK_SUBPASS_CONTENTS_INLINE);
-
-  //Add a barrier so the next stage can read the pass
+  // --- LOCAL READ BARRIER ---
   VkMemoryBarrier2KHR memoryBarrier{};
   memoryBarrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2_KHR;
-  memoryBarrier.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
-  memoryBarrier.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
-  memoryBarrier.srcAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
-  memoryBarrier.dstAccessMask = VK_ACCESS_2_INPUT_ATTACHMENT_READ_BIT;
+  memoryBarrier.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR;
+  memoryBarrier.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR;
+  memoryBarrier.srcAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT_KHR;
+  memoryBarrier.dstAccessMask = VK_ACCESS_2_INPUT_ATTACHMENT_READ_BIT_KHR;
 
   VkDependencyInfoKHR dependencyInfo{};
   dependencyInfo.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR;
@@ -529,11 +562,24 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
 
   vkCmdPipelineBarrier2(cmd, &dependencyInfo);
 
-  // COMPOSITE PASS
-  // Averages out the summed colors (in some sense) to get the final transparent color.
+  // --- SUBPASS 2: COMPOSITE ---
   {
+    VkRenderingAttachmentLocationInfoKHR locationInfo{VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO_KHR};
+    locationInfo.colorAttachmentCount = 3;
+
+    // Shader writes output 0 -> Attachment 2. Skip Attachments 0 & 1.
+    uint32_t compositeLocations[3] = {VK_ATTACHMENT_UNUSED, VK_ATTACHMENT_UNUSED, 0};
+    locationInfo.pColorAttachmentLocations = compositeLocations;
+    //vkCmdSetRenderingAttachmentLocationsKHR(cmd, &locationInfo);
+
+    // Map shader input_attachment_index 0 -> Attachment 0, index 1 -> Attachment 1
+    VkRenderingInputAttachmentIndexInfoKHR inputInfo{VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR};
+    inputInfo.colorAttachmentCount = 3;
+    uint32_t inputIndices[3] = {VK_ATTACHMENT_UNUSED, 1, 0 };
+    inputInfo.pColorAttachmentInputIndices = inputIndices;
+    //vkCmdSetRenderingInputAttachmentIndices(cmd, &inputInfo);
+
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipelines[+PassIndex::eWeightedComposite]);
-    // Draw a full-screen triangle
     vkCmdDraw(cmd, 3, 1, 0, 0);
   }
 }

--- a/oitRender.cpp
+++ b/oitRender.cpp
@@ -90,14 +90,47 @@ void Sample::onRender(VkCommandBuffer cmd)
     clearValues[0].color                    = {0.2f, 0.2f, 0.2f, 0.2f};  // Background color, in linear space
     clearValues[1].depthStencil             = {1.0f, 0};                 // Clear depth
 
-    const VkRenderPassBeginInfo renderPassInfo{.sType       = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
-                                               .renderPass  = m_renderPassColorDepthClear,
-                                               .framebuffer = m_mainColorDepthFramebuffer,
-                                               .renderArea = {.extent = {m_colorImage.getWidth(), m_colorImage.getHeight()}},
-                                               .clearValueCount = uint32_t(clearValues.size()),
-                                               .pClearValues    = clearValues.data()};
+    //Attachment Info for Dynamic rendering
+    VkRenderingAttachmentInfo colorAttachmentInfo =
+    {
+      .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+      .pNext = nullptr,
+      .imageView = m_colorImage.getView(),
+      .imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+      .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+      .clearValue = clearValues[0],
+    };
 
-    vkCmdBeginRenderPass(cmd, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
+    VkRenderingAttachmentInfo depthAttachmentInfo =
+    {
+      .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+      .pNext = nullptr,
+      .imageView = m_depthImage.getView(),
+      .imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+      .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+      .clearValue = clearValues[1],
+    };
+
+    // Dynamic rendering info
+    VkRenderingInfo render_info = { VK_STRUCTURE_TYPE_RENDERING_INFO_KHR };
+    render_info.renderArea          = {.extent = {m_colorImage.getWidth(), m_colorImage.getHeight()}},
+    render_info.layerCount          = 1;
+    render_info.colorAttachmentCount = 1;
+    render_info.pColorAttachments   = &colorAttachmentInfo;
+    render_info.pDepthAttachment    = &depthAttachmentInfo;
+
+    // const VkRenderPassBeginInfo renderPassInfo{.sType       = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+    //                                            .renderPass  = m_renderPassColorDepthClear,
+    //                                            .framebuffer = m_mainColorDepthFramebuffer,
+    //                                            .renderArea = {.extent = {m_colorImage.getWidth(), m_colorImage.getHeight()}},
+    //                                            .clearValueCount = uint32_t(clearValues.size()),
+    //                                            .pClearValues    = clearValues.data()};
+
+    //TODO: Change this to start and below to end dynamic rendering
+    vkCmdBeginRendering(cmd, &render_info);
+    //vkCmdBeginRenderPass(cmd, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     // Bind the vertex and index buffers
     const VkDeviceSize offset = 0;
@@ -147,7 +180,8 @@ void Sample::onRender(VkCommandBuffer cmd)
         assert(!"Algorithm case not called in switch statement!");
     }
 
-    vkCmdEndRenderPass(cmd);
+    //vkCmdEndRenderPass(cmd);
+    vkCmdEndRendering(cmd);
   }
 
   copyOffscreenToBackBuffer(cmd);
@@ -384,7 +418,8 @@ void Sample::drawTransparentLock(VkCommandBuffer& cmd, int numObjects, bool useI
 void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
 {
   // Swap out the render pass for WBOIT's render pass
-  vkCmdEndRenderPass(cmd);
+  //vkCmdEndRenderPass(cmd);
+  vkCmdEndRendering(cmd);
 
   auto section = m_profilerGPU.cmdFrameSection(cmd, "WeightedBlendedOIT");
 
@@ -395,15 +430,75 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
   clearValues[0].color = VkClearColorValue{.float32 = {0.0f, 0.0f, 0.0f, 0.0f}};
   // Initially, all pixels show through all the way (reveal = 100%)
   clearValues[1].color = VkClearColorValue{.float32 = {1.0f}};
-  const VkRenderPassBeginInfo renderPassInfo{.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
-                                             .renderPass      = m_renderPassWeighted,
-                                             .framebuffer     = m_weightedFramebuffer,
-                                             .renderArea      = {.extent = {.width  = m_oitWeightedColorImage.getWidth(),
-                                                                            .height = m_oitWeightedColorImage.getHeight()}},
-                                             .clearValueCount = uint32_t(clearValues.size()),
-                                             .pClearValues    = clearValues.data()};
 
-  vkCmdBeginRenderPass(cmd, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
+  std::array<VkRenderingAttachmentInfo,3> colorInfo =
+  {{
+    //Image 0
+    {
+      .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+      .pNext = nullptr,
+      .imageView = m_oitWeightedColorImage.getView(),
+      .imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+      .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+      .clearValue = clearValues[0],
+    },
+
+    //Image 1
+    {
+      .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+      .pNext = nullptr,
+      .imageView = m_oitWeightedRevealImage.getView(),
+      .imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+      .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+      .clearValue = clearValues[1],
+   },
+
+    //Frame image
+    {
+      .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+      .pNext = nullptr,
+      .imageView = m_colorImage.getView(),
+      .imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+      .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+      .clearValue = clearValues[0],
+    }
+  }};
+
+  // const VkRenderPassBeginInfo renderPassInfo{.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+  //                                            .renderPass      = m_renderPassWeighted,
+  //                                            .framebuffer     = m_weightedFramebuffer,
+  //                                            .renderArea      = {.extent = {.width  = m_oitWeightedColorImage.getWidth(),
+  //                                                                           .height = m_oitWeightedColorImage.getHeight()}},
+  //                                            .clearValueCount = uint32_t(clearValues.size()),
+  //                                            .pClearValues    = clearValues.data()};
+
+  //Depth Image
+  VkRenderingAttachmentInfo depthInfo =
+  {
+    .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+    .pNext = nullptr,
+    .imageView = m_colorImage.getView(),
+    .imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+    .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+    .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+    .clearValue = clearValues[1],
+  };
+
+
+  VkRenderingInfo renderInfo =
+  {
+    .sType = VK_STRUCTURE_TYPE_RENDERING_INFO,
+    .pNext = nullptr,
+    .colorAttachmentCount = (uint32_t) colorInfo.size(),
+    .pColorAttachments = colorInfo.data(),
+    .pDepthAttachment  = &depthInfo,
+  };
+
+  //vkCmdBeginRenderPass(cmd, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
+  vkCmdBeginRendering(cmd, &renderInfo);
 
   // COLOR PASS
   // Computes the weighted sum and reveal factor.
@@ -414,7 +509,24 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
   }
 
   // Move to the next subpass
-  vkCmdNextSubpass(cmd, VK_SUBPASS_CONTENTS_INLINE);
+  //vkCmdNextSubpass(cmd, VK_SUBPASS_CONTENTS_INLINE);
+
+  //Add a barrier so the next stage can read the pass
+  VkMemoryBarrier2KHR memoryBarrier{};
+  memoryBarrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2_KHR;
+  memoryBarrier.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
+  memoryBarrier.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
+  memoryBarrier.srcAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
+  memoryBarrier.dstAccessMask = VK_ACCESS_2_INPUT_ATTACHMENT_READ_BIT;
+
+  VkDependencyInfoKHR dependencyInfo{};
+  dependencyInfo.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR;
+  dependencyInfo.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+  dependencyInfo.memoryBarrierCount = 1;
+  dependencyInfo.pMemoryBarriers = &memoryBarrier;
+
+  vkCmdPipelineBarrier2(cmd, &dependencyInfo);
+
   // COMPOSITE PASS
   // Averages out the summed colors (in some sense) to get the final transparent color.
   {

--- a/oitRender.cpp
+++ b/oitRender.cpp
@@ -461,7 +461,7 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
       .pNext = nullptr,
       .imageView = m_colorImage.getView(),
       .imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-      .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+      .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
       .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
       .clearValue = clearValues[0],
     }
@@ -480,9 +480,9 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
   {
     .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
     .pNext = nullptr,
-    .imageView = m_colorImage.getView(),
-    .imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
-    .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+    .imageView = m_depthImage.getView(),
+    .imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+    .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
     .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
     .clearValue = clearValues[1],
   };
@@ -492,6 +492,8 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
   {
     .sType = VK_STRUCTURE_TYPE_RENDERING_INFO,
     .pNext = nullptr,
+    .renderArea = {.extent = {.width  = m_colorImage.getWidth(), .height = m_colorImage.getHeight()}},
+    .layerCount = 1,
     .colorAttachmentCount = (uint32_t) colorInfo.size(),
     .pColorAttachments = colorInfo.data(),
     .pDepthAttachment  = &depthInfo,

--- a/oitRender.cpp
+++ b/oitRender.cpp
@@ -417,8 +417,6 @@ void Sample::drawTransparentLock(VkCommandBuffer& cmd, int numObjects, bool useI
 
 void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
 {
-  // Swap out the render pass for WBOIT's render pass
-  //vkCmdEndRenderPass(cmd);
   // End the opaque rendering block
   vkCmdEndRendering(cmd);
 
@@ -426,8 +424,8 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
 
   m_colorImage.transitionTo(cmd, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
   m_depthImage.transitionTo(cmd, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
-  // m_oitWeightedColorImage.transitionTo(cmd, VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR);
-  // m_oitWeightedRevealImage.transitionTo(cmd, VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR);
+
+  //Creating the layout manually sice transitionTo() does not support VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR as of this writing
 
   //m_oitWeightedColorImage layout transition
   VkImageMemoryBarrier2KHR imageMemoryBarrierColorImage{};
@@ -469,7 +467,6 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
     };
   imageMemoryBarrierRevealageImage.image            = m_oitWeightedRevealImage.image.image;
 
-  VkDependencyInfoKHR dependencyInfoRevealageImage{};
   dependencyInfoColorImage.sType                   = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR;
   dependencyInfoColorImage.imageMemoryBarrierCount = 1;
   dependencyInfoColorImage.pImageMemoryBarriers    = &imageMemoryBarrierRevealageImage;
@@ -479,7 +476,8 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
   clearValues[0].color = VkClearColorValue{.float32 = {0.0f, 0.0f, 0.0f, 0.0f}};
   clearValues[1].color = VkClearColorValue{.float32 = {1.0f, 0.0f, 0.0f, 0.0f}}; // Reveal starts at 1.0
 
-  std::array<VkRenderingAttachmentInfo, 3> colorInfo = {{
+  //Color attachments that will be used for both passes of WBOIT
+  std::array<VkRenderingAttachmentInfo, 3> colorAttachmentsInfo = {{
     // 0: Main Color Output (Load existing opaque geometry)
     {
       .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
@@ -525,23 +523,25 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
     .pNext = nullptr,
     .renderArea = {.extent = {.width = m_colorImage.getWidth(), .height = m_colorImage.getHeight()}},
     .layerCount = 1,
-    .colorAttachmentCount = static_cast<uint32_t>(colorInfo.size()),
-    .pColorAttachments = colorInfo.data(),
+    .colorAttachmentCount = static_cast<uint32_t>(colorAttachmentsInfo.size()),
+    .pColorAttachments = colorAttachmentsInfo.data(),
     .pDepthAttachment  = &depthInfo,
   };
 
   vkCmdBeginRendering(cmd, &renderInfo);
 
-  //vkCmdSetRenderingInputAttachmentIndices(cmd, &rendering_attachment_index_info);
   // --- SUBPASS 1: COLOR ACCUMULATION ---
   {
-    //For first pass, write to images 1 and 2
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipelines[+PassIndex::eWeightedColor]);
-    vkCmdSetRenderingAttachmentLocations(cmd, &locationInfo);
+
+    //Since we are using dynamic subpasses, we need to tell the driver which image attachments will be used to accept shader output writes.
+    //For first pass, write to images 1 and 2
+    vkCmdSetRenderingAttachmentLocations(cmd, &m_wboitColorAttachmentLocationInfo);
     vkCmdDrawIndexed(cmd, numObjects * m_objectTriangleIndices, 1, 0, 0, 0);
   }
 
   // --- LOCAL READ BARRIER ---
+  //We need to include this barrier so the next stage can read pixel information from the previous phase
   VkMemoryBarrier2KHR memoryBarrier{};
   memoryBarrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2_KHR;
   memoryBarrier.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR;
@@ -559,10 +559,14 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
 
   // --- SUBPASS 2: COMPOSITE ---
   {
-    //Only read last two entries
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipelines[+PassIndex::eWeightedComposite]);
-    vkCmdSetRenderingAttachmentLocations(cmd, &resetLocationInfo);
-    vkCmdSetRenderingInputAttachmentIndices(cmd, &rendering_attachment_index_info);
+
+    //Firstly, we need to reset the shader writing output order in this pass.
+    vkCmdSetRenderingAttachmentLocations(cmd, &m_wboitCompositeResetAttachmentLocationsInfo);
+
+    //Next, we only read the last two entries to composite the accumulation and revealage passes.
+    //Note that this won't work without the proper blend settings that are set in createGraphicsPipeline()
+    vkCmdSetRenderingInputAttachmentIndices(cmd, &m_wboitCompositeAttachmentInputIndicesInfo);
     vkCmdDraw(cmd, 3, 1, 0, 0);
   }
 }

--- a/oitRender.cpp
+++ b/oitRender.cpp
@@ -114,23 +114,14 @@ void Sample::onRender(VkCommandBuffer cmd)
     };
 
     // Dynamic rendering info
-    VkRenderingInfo render_info = { VK_STRUCTURE_TYPE_RENDERING_INFO_KHR };
-    render_info.renderArea          = {.extent = {m_colorImage.getWidth(), m_colorImage.getHeight()}},
-    render_info.layerCount          = 1;
-    render_info.colorAttachmentCount = 1;
-    render_info.pColorAttachments   = &colorAttachmentInfo;
-    render_info.pDepthAttachment    = &depthAttachmentInfo;
+    VkRenderingInfo dynamicRenderInfo = { VK_STRUCTURE_TYPE_RENDERING_INFO_KHR };
+    dynamicRenderInfo.renderArea          = {.extent = {m_colorImage.getWidth(), m_colorImage.getHeight()}},
+    dynamicRenderInfo.layerCount          = 1;
+    dynamicRenderInfo.colorAttachmentCount = 1;
+    dynamicRenderInfo.pColorAttachments   = &colorAttachmentInfo;
+    dynamicRenderInfo.pDepthAttachment    = &depthAttachmentInfo;
 
-    // const VkRenderPassBeginInfo renderPassInfo{.sType       = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
-    //                                            .renderPass  = m_renderPassColorDepthClear,
-    //                                            .framebuffer = m_mainColorDepthFramebuffer,
-    //                                            .renderArea = {.extent = {m_colorImage.getWidth(), m_colorImage.getHeight()}},
-    //                                            .clearValueCount = uint32_t(clearValues.size()),
-    //                                            .pClearValues    = clearValues.data()};
-
-    //TODO: Change this to start and below to end dynamic rendering
-    vkCmdBeginRendering(cmd, &render_info);
-    //vkCmdBeginRenderPass(cmd, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
+    vkCmdBeginRendering(cmd, &dynamicRenderInfo);
 
     // Bind the vertex and index buffers
     const VkDeviceSize offset = 0;
@@ -425,7 +416,8 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
   m_colorImage.transitionTo(cmd, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
   m_depthImage.transitionTo(cmd, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
 
-  //Creating the layout manually sice transitionTo() does not support VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR as of this writing
+  //Creating the image layout manually for color and revealage images as transitionTo() does not
+  //support VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR as of this writing
 
   //m_oitWeightedColorImage layout transition
   VkImageMemoryBarrier2KHR imageMemoryBarrierColorImage{};
@@ -472,6 +464,7 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
   dependencyInfoColorImage.pImageMemoryBarriers    = &imageMemoryBarrierRevealageImage;
   vkCmdPipelineBarrier2(cmd, &dependencyInfoColorImage);
 
+  //Set up clear values for the images
   std::array<VkClearValue, 2> clearValues;
   clearValues[0].color = VkClearColorValue{.float32 = {0.0f, 0.0f, 0.0f, 0.0f}};
   clearValues[1].color = VkClearColorValue{.float32 = {1.0f, 0.0f, 0.0f, 0.0f}}; // Reveal starts at 1.0
@@ -509,7 +502,7 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
    },
   }};
 
-  VkRenderingAttachmentInfo depthInfo = {
+  VkRenderingAttachmentInfo depthAttachmentInfo = {
     .sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
     .pNext = nullptr,
     .imageView = m_depthImage.getView(),
@@ -518,17 +511,17 @@ void Sample::drawTransparentWeighted(VkCommandBuffer& cmd, int numObjects)
     .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
   };
 
-  VkRenderingInfo renderInfo = {
+  VkRenderingInfo renderingAttachmentInfo = {
     .sType = VK_STRUCTURE_TYPE_RENDERING_INFO,
     .pNext = nullptr,
     .renderArea = {.extent = {.width = m_colorImage.getWidth(), .height = m_colorImage.getHeight()}},
     .layerCount = 1,
     .colorAttachmentCount = static_cast<uint32_t>(colorAttachmentsInfo.size()),
     .pColorAttachments = colorAttachmentsInfo.data(),
-    .pDepthAttachment  = &depthInfo,
+    .pDepthAttachment  = &depthAttachmentInfo,
   };
 
-  vkCmdBeginRendering(cmd, &renderInfo);
+  vkCmdBeginRendering(cmd, &renderingAttachmentInfo);
 
   // --- SUBPASS 1: COLOR ACCUMULATION ---
   {


### PR DESCRIPTION
Added support for Vulkan Dynamic Rendering and Dynamic Rendering Local Read for subpassInputs used in Weighted OIT shaders. Removed Framebuffers and Renderpasses from rendering code.